### PR TITLE
Use access_token instead of token

### DIFF
--- a/src/api/r0/account.rs
+++ b/src/api/r0/account.rs
@@ -71,7 +71,7 @@ mod tests {
 
         assert!(
             test.post(
-                &format!("/_matrix/client/r0/account/password?token={}", access_token),
+                &format!("/_matrix/client/r0/account/password?access_token={}", access_token),
                 r#"{"new_password": "hidden"}"#
             ).status.is_success()
         );

--- a/src/api/r0/create_room.rs
+++ b/src/api/r0/create_room.rs
@@ -97,7 +97,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let create_room_path = format!("/_matrix/client/r0/createRoom?token={}", access_token);
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
 
         let response = test.post(&create_room_path, "{}");
 
@@ -109,7 +110,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let create_room_path = format!("/_matrix/client/r0/createRoom?token={}", access_token);
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
 
         let response = test.post(&create_room_path, r#"{"room_alias_name": "my_room"}"#);
 
@@ -121,7 +123,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let create_room_path = format!("/_matrix/client/r0/createRoom?token={}", access_token);
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
 
         let response = test.post(&create_room_path, r#"{"visibility": "public"}"#);
 
@@ -133,7 +136,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let create_room_path = format!("/_matrix/client/r0/createRoom?token={}", access_token);
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
 
         let response = test.post(&create_room_path, r#"{"visibility": "private"}"#);
 
@@ -145,7 +149,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let create_room_path = format!("/_matrix/client/r0/createRoom?token={}", access_token);
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
 
         let response = test.post(&create_room_path, r#"{"visibility": "bogus"}"#);
 

--- a/src/api/r0/logout.rs
+++ b/src/api/r0/logout.rs
@@ -43,7 +43,8 @@ mod tests {
         let test = Test::new();
         let access_token = test.create_access_token();
 
-        let login_path = format!("/_matrix/client/r0/logout?token={}", access_token);
+        let login_path = format!("/_matrix/client/r0/logout?access_token={}",
+                                 access_token);
 
         assert!(test.post(&login_path, "{}").status.is_success());
         assert_eq!(test.post(&login_path, "{}").status, Status::Forbidden);

--- a/src/middleware/authentication.rs
+++ b/src/middleware/authentication.rs
@@ -33,7 +33,7 @@ impl BeforeMiddleware for AccessTokenAuth {
 
         if let Some(query_pairs) = request.url.clone().into_generic_url().query_pairs() {
             if let Some(&(_, ref token)) = query_pairs.iter().find(
-                |&&(ref key, _)| key == "token"
+                |&&(ref key, _)| key == "access_token"
             ) {
                 if let Ok(access_token) = AccessToken::find_valid_by_token(&connection, &token) {
                     if let Ok(user) = User::find_by_access_token(&connection, &access_token) {


### PR DESCRIPTION
According to the [spec](http://matrix.org/docs/spec/client_server/r0.1.0.html#client-authentication), the access token should be provided as a query parameter named "access_token", not "token".
