### PR TITLE
Implement GET /directory/room/:room_alias

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -162,7 +162,7 @@ Legend:
     <td>DELETE /directory/room/:room_alias</td>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:white_check_mark:</td>
     <td><a href="https://github.com/ruma/ruma/issues/21">#21</a></td>
     <td>GET /directory/room/:room_alias</td>
   </tr>

--- a/src/api/r0/directory.rs
+++ b/src/api/r0/directory.rs
@@ -1,0 +1,92 @@
+//! Endpoints for managing room aliases.
+
+use iron::{Chain, Handler, IronResult, Request, Response};
+use iron::status::Status;
+use router::Router;
+
+use db::DB;
+use error::APIError;
+use middleware::{AccessTokenAuth, JsonRequest};
+use modifier::SerializableResponse;
+use room_alias::RoomAlias;
+
+#[derive(Debug, Serialize)]
+struct GetDirectoryRoomResponse {
+    room_id: String,
+    servers: Vec<String>,
+}
+
+/// The /directory/room/{roomAlias} endpoint when using the GET method.
+pub struct GetDirectoryRoom;
+
+impl GetDirectoryRoom {
+    /// Create a `DirectoryRoom`.
+    pub fn chain() -> Chain {
+        Chain::new(GetDirectoryRoom)
+    }
+}
+
+impl Handler for GetDirectoryRoom {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let params = request.extensions.get::<Router>().expect("Params object is missing").clone();
+
+        let room_alias_name = params.find("room_alias").ok_or(APIError::not_found())?;
+
+        let connection = DB::from_request(request)?;
+
+        let room_alias = RoomAlias::find_by_alias(&connection, room_alias_name)?;
+
+        let response = GetDirectoryRoomResponse {
+            room_id: room_alias.room_id,
+            servers: room_alias.servers,
+        };
+
+        Ok(Response::with((Status::Ok, SerializableResponse(response))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test::Test;
+    use iron::status::Status;
+
+    #[test]
+    fn get_room_alias() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
+        let response = test.post(&create_room_path, r#"{"room_alias_name": "my_room"}"#);
+        let room_id = response.json().find("room_id").unwrap().as_string();
+
+        let get_room_alias_path = format!(
+            "/_matrix/client/r0/directory/room/my_room?access_token={}", access_token
+        );
+        let response = test.get(&get_room_alias_path);
+
+        assert_eq!(response.json().find("room_id").unwrap().as_string(), room_id);
+        assert!(response.json().find("servers").unwrap().is_array());
+    }
+
+    #[test]
+    fn get_unknown_room_alias() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+
+        let create_room_path = format!("/_matrix/client/r0/createRoom?access_token={}",
+                                       access_token);
+        let _ = test.post(&create_room_path, r#"{"room_alias_name": "my_room"}"#);
+
+        let get_room_alias_path = format!(
+            "/_matrix/client/r0/directory/room/no_room?access_token={}", access_token
+        );
+        let response = test.get(&get_room_alias_path);
+
+        assert_eq!(response.status, Status::NotFound);
+        assert_eq!(
+            response.json().find("errcode").unwrap().as_string().unwrap(),
+            "M_NOT_FOUND"
+        );
+    }
+}

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -5,6 +5,7 @@ pub use self::create_room::CreateRoom;
 pub use self::login::Login;
 pub use self::logout::Logout;
 pub use self::registration::Register;
+pub use self::directory::GetDirectoryRoom;
 pub use self::versions::Versions;
 
 mod account;
@@ -12,4 +13,5 @@ mod create_room;
 mod login;
 mod logout;
 mod registration;
+mod directory;
 mod versions;

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,14 @@ impl APIError {
         }
     }
 
+    /// Create an error for requests that do not map to a resource.
+    pub fn not_found() -> APIError {
+        APIError {
+            errcode: APIErrorCode::NotFound,
+            error: "No resource was found for this request.".to_string(),
+        }
+    }
+
     /// Create an error for requests without JSON bodies.
     pub fn not_json() -> APIError {
         APIError {

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,6 +12,7 @@ use router::Router;
 use api::r0::{
     AccountPassword,
     CreateRoom,
+    GetDirectoryRoom,
     Login,
     Logout,
     Register,
@@ -47,6 +48,7 @@ impl<'a> Server<'a> {
 
         r0_router.post("/account/password", AccountPassword::chain());
         r0_router.post("/createRoom", CreateRoom::chain());
+        r0_router.get("/directory/room/:room_alias", GetDirectoryRoom::chain());
         r0_router.post("/login", Login::chain());
         r0_router.post("/logout", Logout::chain());
         r0_router.post("/register", Register::chain());


### PR DESCRIPTION
This adds a module `directory` under `api::r0` where the `/directory/room/:room_alias` endpoint is implemented. So far, I've only implemented the GET verb.

Closes #21.
