### PR TITLE
Revert ae2ced5 and fix tests

### DIFF
--- a/src/api/r0/directory.rs
+++ b/src/api/r0/directory.rs
@@ -6,7 +6,6 @@ use router::Router;
 
 use db::DB;
 use error::APIError;
-use middleware::AccessTokenAuth;
 use modifier::SerializableResponse;
 use room_alias::RoomAlias;
 
@@ -22,11 +21,7 @@ pub struct GetDirectoryRoom;
 impl GetDirectoryRoom {
     /// Create a `DirectoryRoom`.
     pub fn chain() -> Chain {
-        let mut chain = Chain::new(GetDirectoryRoom);
-
-        chain.link_before(AccessTokenAuth);
-
-        chain
+        Chain::new(GetDirectoryRoom)
     }
 }
 
@@ -64,10 +59,7 @@ mod tests {
         let response = test.post(&create_room_path, r#"{"room_alias_name": "my_room"}"#);
         let room_id = response.json().find("room_id").unwrap().as_string();
 
-        let get_room_alias_path = format!(
-            "/_matrix/client/r0/directory/room/my_room?access_token={}", access_token
-        );
-        let response = test.get(&get_room_alias_path);
+        let response = test.get("/_matrix/client/r0/directory/room/my_room");
 
         assert_eq!(response.json().find("room_id").unwrap().as_string(), room_id);
         assert!(response.json().find("servers").unwrap().is_array());
@@ -82,10 +74,7 @@ mod tests {
                                        access_token);
         let _ = test.post(&create_room_path, r#"{"room_alias_name": "my_room"}"#);
 
-        let get_room_alias_path = format!(
-            "/_matrix/client/r0/directory/room/no_room?access_token={}", access_token
-        );
-        let response = test.get(&get_room_alias_path);
+        let response = test.get("/_matrix/client/r0/directory/room/no_room");
 
         assert_eq!(response.status, Status::NotFound);
         assert_eq!(


### PR DESCRIPTION
I accidentally copy-pasted an URL with an `access_token` query parameter
for testing the GET verb on the `/directory/room/:room_alias`
endpoint in 6cd596d. This was never used in the implementation of the request
because according to the spec [1], GET on this endpoint does not require
authentication. This commit reverts the addition of the
`AccessTokenAuth` middleware done in ae2ced5 and removes the
`access_token` parameter from the tests.

[1] http://matrix.org/docs/spec/client_server/r0.1.0.html#get-matrix-client-r0-directory-room-roomalias
