### PR TITLE
Require authentication for deleting room aliases

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -157,7 +157,7 @@ Legend:
     <td>PUT /directory/room/:room_alias</td>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:construction:</td>
     <td><a href="https://github.com/ruma/ruma/issues/20">#20</a></td>
     <td>DELETE /directory/room/:room_alias</td>
   </tr>

--- a/src/room_alias.rs
+++ b/src/room_alias.rs
@@ -64,9 +64,6 @@ impl RoomAlias {
 
         delete(thing)
             .execute(connection)
-            .map_err(|err| match err {
-                DieselError::NotFound => APIError::not_found(),
-                _ => APIError::from(err),
-            })
+            .map_err(APIError::from)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -111,8 +111,8 @@ impl Test {
         self.request(Method::Post, path, body)
     }
 
-    pub fn delete(&self, path: &str, body: &str) -> Response {
-        self.request(Method::Delete, path, body)
+    pub fn delete(&self, path: &str) -> Response {
+        self.request(Method::Delete, path, "")
     }
 
     pub fn request(&self, method: Method, path: &str, body: &str) -> Response {


### PR DESCRIPTION
This adds an authentication middleware to DELETE
/directory/room/:room_alias, as mandated by the spec, and updates the
test accordingly. The test now actually checks the status code of the
response to the DELETE request. Furthermore, the `delete` helper method
in `test.rs` has been modified to not require a body.

Marks the endpoint as done in STATUS.md.
