### PR TITLE
Increase the portability of the Cargo wrapper

### DIFF
--- a/script/cargo
+++ b/script/cargo
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 docker-compose run --rm -e RUST_BACKTRACE=1 rust cargo "$@"


### PR DESCRIPTION
This common shebang hack allows the Bash binary to be in any directory, as long as that directory is in the PATH. This is useful for systems such as NixOS or GoboLinux, which use nonstandard directories. 
