### PR TITLE
Add basic implementation for the /account/deactivate endpoint.

### DIFF
--- a/migrations/001_create_users/up.sql
+++ b/migrations/001_create_users/up.sql
@@ -1,6 +1,7 @@
 CREATE TABLE users (
   id TEXT NOT NULL PRIMARY KEY,
   password_hash TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
   created_at TIMESTAMP NOT NULL DEFAULT now(),
   updated_at TIMESTAMP NOT NULL DEFAULT now()
 );

--- a/migrations/006_create_account_data/down.sql
+++ b/migrations/006_create_account_data/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE account_data;

--- a/migrations/006_create_account_data/up.sql
+++ b/migrations/006_create_account_data/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE account_data (
+    id BIGSERIAL PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    data_type TEXT NOT NULL,
+    content TEXT NOT NULL,
+    UNIQUE (user_id, data_type)
+);

--- a/src/account_data.rs
+++ b/src/account_data.rs
@@ -1,0 +1,79 @@
+//! Account information stored for a user.
+
+use diesel::{
+    ExpressionMethods,
+    FilterDsl,
+    LoadDsl,
+    SaveChangesDsl,
+    insert,
+};
+use diesel::result::Error as DieselError;
+use diesel::pg::PgConnection;
+use iron::typemap::Key;
+use ruma_identifiers::UserId;
+
+use error::ApiError;
+use schema::account_data;
+
+/// Holds personal information/configuration for a user.
+#[derive(Debug, Clone, Identifiable, Queryable)]
+#[changeset_for(account_data)]
+#[table_name="account_data"]
+pub struct AccountData {
+    /// Entry ID
+    pub id: i64,
+    /// The user's unique ID.
+    pub user_id: UserId,
+    /// The type of the data.
+    pub data_type: String,
+    /// The contents.
+    pub content: String,
+}
+
+/// New account data, not yet saved.
+#[derive(Debug)]
+#[insertable_into(account_data)]
+pub struct NewAccountData {
+    /// The ID of the user who owns the data.
+    pub user_id: UserId,
+    /// The type of the data to be saved.
+    pub data_type: String,
+    /// The contents.
+    pub content: String,
+}
+
+impl AccountData {
+    /// Create new `AccountData` for a user.
+    pub fn create(connection: &PgConnection, new_account_data: NewAccountData)
+    -> Result<Self, ApiError> {
+        insert(&new_account_data)
+            .into(account_data::table)
+            .get_result(connection)
+            .map_err(ApiError::from)
+    }
+
+    /// Look up an `AccountData` entry using the `UserId` and the data type of the data.
+    pub fn find_by_uid_and_type(connection: &PgConnection, user_id: &UserId, data_type: &str)
+    -> Result<AccountData, DieselError> {
+        account_data::table
+            .filter(account_data::user_id.eq(user_id))
+            .filter(account_data::data_type.eq(data_type))
+            .first(connection)
+            .map(AccountData::from)
+    }
+
+    /// Update an `AccountData` entry with new content.
+    pub fn update(&mut self, connection: &PgConnection, content: String)
+    -> Result<(), ApiError> {
+        self.content = content;
+
+        match self.save_changes::<AccountData>(connection) {
+            Ok(_) => Ok(()),
+            Err(error) => Err(ApiError::from(error)),
+        }
+    }
+}
+
+impl Key for AccountData {
+    type Value = AccountData;
+}

--- a/src/api/r0/account.rs
+++ b/src/api/r0/account.rs
@@ -1,14 +1,21 @@
 use bodyparser;
 use diesel::SaveChangesDsl;
+use diesel::result::Error as DieselError;
 use iron::{Chain, Handler, IronError, IronResult, Plugin, Request, Response};
 use iron::status::Status;
+
+use std::convert::TryFrom;
+use std::error::Error;
 
 use crypto::hash_password;
 use db::DB;
 use error::ApiError;
-use middleware::AccessTokenAuth;
+use middleware::{AccessTokenAuth, JsonRequest};
 use user::User;
+use ruma_identifiers::UserId;
+use router::Router;
 use access_token::AccessToken;
+use account_data::{AccountData, NewAccountData};
 
 /// The /account/password endpoint.
 #[derive(Debug)]
@@ -18,10 +25,6 @@ pub struct AccountPassword;
 struct AccountPasswordRequest {
     pub new_password: String,
 }
-
-/// The /account/deactivate endpoint.
-#[derive(Debug)]
-pub struct DeactivateAccount;
 
 impl AccountPassword {
     /// Create an `AccountPassword` with all necessary middleware.
@@ -65,6 +68,11 @@ impl Handler for AccountPassword {
     }
 }
 
+
+/// The /account/deactivate endpoint.
+#[derive(Debug)]
+pub struct DeactivateAccount;
+
 impl DeactivateAccount {
     /// Create a `DeactivateAccount` with all necessary middleware.
     pub fn chain() -> Chain {
@@ -96,7 +104,121 @@ impl Handler for DeactivateAccount {
             return Err(IronError::new(error.clone(), error));
         };
 
-        // TODO: Delete 3pid for the user
+        // Delete all the account data associated with the user.
+
+        Ok(Response::with(Status::Ok))
+    }
+}
+
+
+/// The /user/:user_id/account_data/:type endpoint.
+#[derive(Debug)]
+pub struct PutAccountData;
+
+impl PutAccountData {
+    /// Create an `PutAccountData` with all necessary middleware.
+    pub fn chain() -> Chain {
+        let mut chain = Chain::new(PutAccountData);
+
+        chain.link_before(JsonRequest);
+        chain.link_before(AccessTokenAuth);
+
+        chain
+    }
+}
+
+impl Handler for PutAccountData {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let params = request.extensions.get::<Router>()
+            .expect("Params object is missing").clone();
+
+        let user = request.extensions.get::<User>()
+            .expect("AccessTokenAuth should ensure a user").clone();
+
+        let content = match request.get::<bodyparser::Json>() {
+            Ok(Some(content)) => content.to_string().clone(),
+            Ok(None) | Err(_) => {
+                let error = ApiError::bad_json(None);
+
+                return Err(IronError::new(error.clone(), error));
+            }
+        };
+
+        // Check if the given user_id corresponds to a registered user.
+        match params.find("user_id") {
+            Some(user_id) => {
+                debug!("user_id param: {}", user_id);
+
+                let uid = match UserId::try_from(user_id) {
+                    Ok(uid) => uid,
+                    Err(err) => {
+                        // TODO: Use invalid_param error
+                        let error = ApiError::missing_param(err.description());
+
+                        return Err(IronError::new(error.clone(), error));
+                    }
+                };
+
+                if uid != user.id {
+                    let error = ApiError::not_found(
+                        Some(&format!("No user found with ID {}", user_id))
+                    );
+
+                    return Err(IronError::new(error.clone(), error));
+                }
+            },
+            None => {
+                let error = ApiError::missing_param("user_id");
+
+                return Err(IronError::new(error.clone(), error));
+            }
+        };
+
+        let data_type = match params.find("type") {
+            Some(data_type) => data_type,
+            None => {
+                let error = ApiError::missing_param("type");
+
+                return Err(IronError::new(error.clone(), error));
+            }
+        };
+
+        let new_data = NewAccountData {
+            user_id: user.id,
+            data_type: String::from(data_type),
+            content: content,
+        };
+
+        let connection = DB::from_request(request)?;
+
+        // Insert or update an existing AccountData entry.
+        match AccountData::find_by_uid_and_type(
+            &connection,
+            &new_data.user_id,
+            &new_data.data_type
+        ) {
+            Ok(mut saved_data) => {
+                if let Err(err) = saved_data.update(&connection, new_data.content) {
+                    return Err(IronError::new(err.clone(), err));
+                }
+            }
+            Err(err) => {
+                match err {
+                    DieselError::NotFound => {
+                        if let Err(err) = AccountData::create(&connection, new_data) {
+                            let error = ApiError::from(err);
+
+                            return Err(IronError::new(error.clone(), error));
+                        }
+                    }
+                    _ => {
+                        let error = ApiError::from(err);
+
+                        return Err(IronError::new(error.clone(), error));
+                    }
+                }
+            }
+        }
 
         Ok(Response::with(Status::Ok))
     }
@@ -135,11 +257,47 @@ mod tests {
         let login = r#"{"auth": {"type": "m.login.password", "user": "carl", "password": "secret"}}"#;
         let deactivate = format!("/_matrix/client/r0/account/deactivate?access_token={}", access_token);
 
-        assert!(test.post("/_matrix/client/r0/login", login).status.is_success());
+        assert!(
+            test.post("/_matrix/client/r0/login", login).status.is_success()
+        );
 
-        assert!(test.post(&deactivate, r#"{}"#).status.is_success());
+        assert!(
+            test.post(&deactivate, r#"{}"#).status.is_success()
+        );
 
-        assert_eq!(test.post("/_matrix/client/r0/login", login).status, Status::Forbidden);
-        assert_eq!(test.post(&deactivate, r#"{}"#).status, Status::Forbidden);
+        assert_eq!(
+            test.post("/_matrix/client/r0/login", login).status,
+            Status::Forbidden
+        );
+
+        assert_eq!(
+            test.post(&deactivate, r#"{}"#).status,
+            Status::Forbidden
+        );
+    }
+
+    #[test]
+    fn update_account_data() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+        let user_id = "@carl:ruma.test";
+
+        let content = r#"{"email": "user@email.com", "phone": "123456789"}"#;
+        let data_type = "org.matrix.personal.config";
+        let account_data_path = format!(
+            "/_matrix/client/r0/user/{}/account_data/{}?access_token={}",
+            user_id, data_type, access_token
+        );
+
+        assert!(
+            test.put(&account_data_path, &content).status.is_success()
+        );
+
+        // Update existing content.
+        let new_content = r#"{"email": "user@email.org", "phone": "123456789", "fax": "123456991"}"#;
+
+        assert!(
+            test.put(&account_data_path, &new_content).status.is_success()
+        );
     }
 }

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -1,6 +1,10 @@
 //! API endpoints for the 0.x.x version of the Matrix spec.
 
-pub use self::account::{AccountPassword, DeactivateAccount};
+pub use self::account::{
+    AccountPassword,
+    DeactivateAccount,
+    PutAccountData,
+};
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
 pub use self::login::Login;

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -1,6 +1,6 @@
 //! API endpoints for the 0.x.x version of the Matrix spec.
 
-pub use self::account::AccountPassword;
+pub use self::account::{AccountPassword, DeactivateAccount};
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
 pub use self::login::Login;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ pub mod access_token;
 pub mod api {
     pub mod r0;
 }
+pub mod account_data;
 pub mod authentication;
 pub mod config;
 pub mod crypto;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,3 +58,12 @@ table! {
         updated_at -> Timestamp,
     }
 }
+
+table! {
+    account_data {
+        id -> BigSerial,
+        user_id -> Text,
+        data_type -> Text,
+        content -> Text,
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -53,6 +53,7 @@ table! {
     users {
         id -> Text,
         password_hash -> Text,
+        active -> Bool,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,12 +11,13 @@ use router::Router;
 
 use api::r0::{
     AccountPassword,
-    DeactivateAccount,
     CreateRoom,
+    DeactivateAccount,
     DeleteRoomAlias,
     GetRoomAlias,
     Login,
     Logout,
+    PutAccountData,
     PutRoomAlias,
     Register,
     SendMessageEvent,
@@ -62,6 +63,7 @@ impl<'a> Server<'a> {
         r0_router.post("/logout", Logout::chain());
         r0_router.post("/register", Register::chain());
         r0_router.post("/tokenrefresh", unimplemented);
+        r0_router.put("/user/:user_id/account_data/:type", PutAccountData::chain());
         r0_router.put(
             "/rooms/:room_id/send/:event_type/:transaction_id",
             SendMessageEvent::chain(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@ use router::Router;
 
 use api::r0::{
     AccountPassword,
+    DeactivateAccount,
     CreateRoom,
     DeleteRoomAlias,
     GetRoomAlias,
@@ -52,6 +53,7 @@ impl<'a> Server<'a> {
         let mut r0_router = Router::new();
 
         r0_router.post("/account/password", AccountPassword::chain());
+        r0_router.post("/account/deactivate", DeactivateAccount::chain());
         r0_router.post("/createRoom", CreateRoom::chain());
         r0_router.get("/directory/room/:room_alias", GetRoomAlias::chain());
         r0_router.delete("/directory/room/:room_alias", DeleteRoomAlias::chain());


### PR DESCRIPTION
I wrote a basic implementation for the deactivate endpoint, but I am not sure if deleting the user
from the database is the best approach.

Maybe we can use a flag?
