### PR TITLE
Add basic implementation for the /rooms/:room_id/join endpoint.

### DIFF
--- a/migrations/007_create_room_memberships/down.sql
+++ b/migrations/007_create_room_memberships/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE room_memberships;

--- a/migrations/007_create_room_memberships/up.sql
+++ b/migrations/007_create_room_memberships/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE room_memberships(
+    event_id TEXT NOT NULL PRIMARY KEY,
+    room_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    sender TEXT NOT NULL,
+    membership TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+

--- a/src/api/r0/join.rs
+++ b/src/api/r0/join.rs
@@ -1,0 +1,138 @@
+//! Endpoints for joining rooms.
+
+use iron::{Chain, Handler, IronResult, Request, Response};
+use iron::status::Status;
+
+use db::DB;
+use config::Config;
+use middleware::{AccessTokenAuth, JsonRequest, RoomIdParam};
+use modifier::SerializableResponse;
+use room_membership::{RoomMembership, RoomMembershipOptions};
+use user::User;
+
+/// The `/rooms/:room_id/join` endpoint.
+pub struct JoinRoom;
+
+#[derive(Debug, Serialize)]
+struct JoinRoomResponse {
+    room_id: String,
+}
+
+impl JoinRoom {
+    /// Create a `JoinRoom` with all necessary middleware.
+    pub fn chain() -> Chain {
+        let mut chain = Chain::new(JoinRoom);
+
+        chain.link_before(JsonRequest);
+        chain.link_before(RoomIdParam);
+        chain.link_before(AccessTokenAuth);
+
+        chain
+    }
+}
+
+impl Handler for JoinRoom {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let user = request.extensions
+            .get::<User>()
+            .expect("AccessTokenAuth should ensure a user")
+            .clone();
+
+        let connection = DB::from_request(request)?;
+        let config = Config::from_request(request)?;
+
+
+        let room_id = request.extensions.get::<RoomIdParam>()
+            .expect("Should have been required by RoomIdParam.")
+            .clone();
+
+        let room_membership_options = RoomMembershipOptions {
+            room_id: room_id.clone(),
+            user_id: user.id.clone(),
+            sender: user.id,
+            membership: String::from("join"),
+        };
+        let room_membership = RoomMembership::create(&connection, &config.domain, room_membership_options)?;
+
+        let response = JoinRoomResponse { room_id: room_membership.room_id.to_string() };
+
+        Ok(Response::with((Status::Ok, SerializableResponse(response))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test::Test;
+    use iron::status::Status;
+
+    #[test]
+    fn join_room() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+        let room_id = test.create_public_room(&access_token);
+
+        let room_join_path = format!(
+            "/_matrix/client/r0/rooms/{}/join?access_token={}",
+            room_id,
+            access_token
+        );
+        let response = test.post(&room_join_path, r"{}");
+        println!("test {:?}", response);
+        assert_eq!(response.status, Status::Ok);
+        assert!(response.json().find("room_id").unwrap().as_str().is_some());
+    }
+
+    #[test]
+    fn rate_limited() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+        let room_id = test.create_public_room(&access_token);
+
+        let room_join_path = format!(
+            "/_matrix/client/r0/rooms/{}/join?access_token={}",
+            room_id,
+            access_token
+        );
+        test.post(&room_join_path, r"{}");
+
+        let room_join_path = format!(
+            "/_matrix/client/r0/rooms/{}/join?access_token={}",
+            room_id,
+            access_token
+        );
+        let response = test.post(&room_join_path, r"{}");
+
+        assert_eq!(response.status, Status::TooManyRequests);
+        assert_eq!(
+            response.json().find("errcode").unwrap().as_str().unwrap(),
+            "M_LIMIT_EXCEEDED"
+        );
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "Try to set the membership again!"
+        );
+    }
+
+    #[test]
+    fn forbidden_joining_private_room() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+        let room_id = test.create_private_room(&access_token);
+
+        let room_join_path = format!(
+            "/_matrix/client/r0/rooms/{}/join?access_token={}",
+            room_id,
+            access_token
+        );
+        let response = test.post(&room_join_path, r"{}");
+        assert_eq!(response.status, Status::Forbidden);
+        assert_eq!(
+            response.json().find("errcode").unwrap().as_str().unwrap(),
+            "M_FORBIDDEN"
+        );
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "You are not invited to this room."
+        );
+    }
+}

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -7,6 +7,7 @@ pub use self::account::{
 };
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
+pub use self::join::JoinRoom;
 pub use self::login::Login;
 pub use self::logout::Logout;
 pub use self::registration::Register;
@@ -16,6 +17,7 @@ pub use self::versions::Versions;
 mod account;
 mod directory;
 mod event_creation;
+mod join;
 mod login;
 mod logout;
 mod registration;

--- a/src/api/r0/room_creation.rs
+++ b/src/api/r0/room_creation.rs
@@ -91,12 +91,20 @@ impl Handler for CreateRoom {
             None => true,
         };
 
+        let preset = match create_room_request.preset {
+            Some(preset) => preset,
+            None => match new_room.public {
+                true => RoomPreset::PublicChat,
+                false => RoomPreset::PrivateChat,
+            }
+        };
+
         let creation_options = CreationOptions {
             alias: create_room_request.room_alias_name,
             federate: federate,
             invite_list: create_room_request.invite,
             name: create_room_request.name,
-            preset: create_room_request.preset,
+            preset: preset,
             topic: create_room_request.topic,
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,14 @@ impl ApiError {
         }
     }
 
+    /// Create an error for Matrix APIs that Ruma intentionally does not implement.
+    pub fn limited_rate(message: Option<&str>) -> ApiError {
+        ApiError {
+            errcode: ApiErrorCode::LimitExceeded,
+            error: message.unwrap_or("Too many retry!").to_string(),
+        }
+    }
+
     /// Create a generic error for anything not specifically covered by the Matrix spec.
     pub fn unknown(message: Option<&str>) -> ApiError {
         ApiError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ pub mod room_alias;
 pub mod schema;
 pub mod server;
 pub mod swagger;
+pub mod room_membership;
 #[cfg(test)] pub mod test;
 pub mod user;
 

--- a/src/room.rs
+++ b/src/room.rs
@@ -48,7 +48,7 @@ pub struct CreationOptions {
     /// An initial name for the room.
     pub name: Option<String>,
     /// A convenience parameter for setting a few default state events.
-    pub preset: Option<RoomPreset>,
+    pub preset: RoomPreset,
     /// An initial topic for the room.
     pub topic: Option<String>,
 }
@@ -169,75 +169,67 @@ impl Room {
                 new_events.push(new_topic_event);
             }
 
-            if let Some(preset) = creation_options.preset {
-                let new_history_visibility_event: NewEvent = HistoryVisibilityEvent {
-                    content: HistoryVisibilityEventContent {
-                        history_visibility: HistoryVisibility::Shared,
-                    },
-                    event_id: EventId::new(homeserver_domain)?,
-                    event_type: EventType::RoomHistoryVisibility,
-                    extra_content: (),
-                    prev_content: None,
-                    room_id: room.id.clone(),
-                    state_key: "".to_string(),
-                    unsigned: None,
-                    user_id: new_room.user_id.clone(),
-                }.try_into()?;
+            let new_history_visibility_event: NewEvent = HistoryVisibilityEvent {
+                content: HistoryVisibilityEventContent {
+                    history_visibility: HistoryVisibility::Shared,
+                },
+                event_id: EventId::new(homeserver_domain)?,
+                event_type: EventType::RoomHistoryVisibility,
+                extra_content: (),
+                prev_content: None,
+                room_id: room.id.clone(),
+                state_key: "".to_string(),
+                unsigned: None,
+                user_id: new_room.user_id.clone(),
+            }.try_into()?;
 
-                new_events.push(new_history_visibility_event);
+            new_events.push(new_history_visibility_event);
 
-                match preset {
-                    RoomPreset::PrivateChat => {
-                        let new_join_rules_event: NewEvent = JoinRulesEvent {
-                            content: JoinRulesEventContent {
-                                join_rule: JoinRule::Invite,
-                            },
-                            event_id: EventId::new(homeserver_domain)?,
-                            event_type: EventType::RoomJoinRules,
-                            extra_content: (),
-                            prev_content: None,
-                            room_id: room.id.clone(),
-                            state_key: "".to_string(),
-                            unsigned: None,
-                            user_id: new_room.user_id.clone(),
-                        }.try_into()?;
+            match creation_options.preset {
+                RoomPreset::PrivateChat => {
+                    let new_join_rules_event: NewEvent = JoinRulesEvent {
+                        content: JoinRulesEventContent { join_rule: JoinRule::Invite },
+                        event_id: EventId::new(homeserver_domain)?,
+                        event_type: EventType::RoomJoinRules,
+                        extra_content: (),
+                        prev_content: None,
+                        room_id: room.id.clone(),
+                        state_key: "".to_string(),
+                        unsigned: None,
+                        user_id: new_room.user_id.clone(),
+                    }.try_into()?;
 
-                        new_events.push(new_join_rules_event);
-                    }
-                    RoomPreset::PublicChat => {
-                        let new_join_rules_event: NewEvent = JoinRulesEvent {
-                            content: JoinRulesEventContent {
-                                join_rule: JoinRule::Public,
-                            },
-                            event_id: EventId::new(homeserver_domain)?,
-                            event_type: EventType::RoomJoinRules,
-                            extra_content: (),
-                            prev_content: None,
-                            room_id: room.id.clone(),
-                            state_key: "".to_string(),
-                            unsigned: None,
-                            user_id: new_room.user_id.clone(),
-                        }.try_into()?;
+                    new_events.push(new_join_rules_event);
+                }
+                RoomPreset::PublicChat => {
+                    let new_join_rules_event: NewEvent = JoinRulesEvent {
+                        content: JoinRulesEventContent { join_rule: JoinRule::Public },
+                        event_id: EventId::new(homeserver_domain)?,
+                        event_type: EventType::RoomJoinRules,
+                        extra_content: (),
+                        prev_content: None,
+                        room_id: room.id.clone(),
+                        state_key: "".to_string(),
+                        unsigned: None,
+                        user_id: new_room.user_id.clone(),
+                    }.try_into()?;
 
-                        new_events.push(new_join_rules_event);
-                    }
-                    RoomPreset::TrustedPrivateChat => {
-                        let new_join_rules_event: NewEvent = JoinRulesEvent {
-                            content: JoinRulesEventContent {
-                                join_rule: JoinRule::Invite,
-                            },
-                            event_id: EventId::new(homeserver_domain)?,
-                            event_type: EventType::RoomJoinRules,
-                            extra_content: (),
-                            prev_content: None,
-                            room_id: room.id.clone(),
-                            state_key: "".to_string(),
-                            unsigned: None,
-                            user_id: new_room.user_id.clone(),
-                        }.try_into()?;
+                    new_events.push(new_join_rules_event);
+                }
+                RoomPreset::TrustedPrivateChat => {
+                    let new_join_rules_event: NewEvent = JoinRulesEvent {
+                        content: JoinRulesEventContent { join_rule: JoinRule::Invite },
+                        event_id: EventId::new(homeserver_domain)?,
+                        event_type: EventType::RoomJoinRules,
+                        extra_content: (),
+                        prev_content: None,
+                        room_id: room.id.clone(),
+                        state_key: "".to_string(),
+                        unsigned: None,
+                        user_id: new_room.user_id.clone(),
+                    }.try_into()?;
 
-                        new_events.push(new_join_rules_event);
-                    }
+                    new_events.push(new_join_rules_event);
                 }
             }
 

--- a/src/room_membership.rs
+++ b/src/room_membership.rs
@@ -1,0 +1,156 @@
+//! Matrix room membership.
+
+use std::convert::TryInto;
+
+use diesel::{
+    Connection,
+    ExpressionMethods,
+    ExecuteDsl,
+    LoadDsl,
+    FilterDsl,
+    insert,
+};
+use diesel::pg::PgConnection;
+use diesel::pg::data_types::PgTimestamp;
+use diesel::result::Error as DieselError;
+use ruma_events::EventType;
+use ruma_events::room::join_rules::JoinRule;
+use ruma_events::room::member::{
+    MemberEvent,
+    MembershipState,
+    MemberEventContent,
+    MemberEventExtraContent};
+use ruma_identifiers::{EventId, RoomId, UserId};
+use serde_json::{Value, from_value};
+
+use error::ApiError;
+use event::{NewEvent, Event};
+use schema::{events, room_memberships};
+
+/// Room membership update or create data.
+#[derive(Debug, Clone)]
+pub struct RoomMembershipOptions {
+    /// The room's ID.
+    pub room_id: RoomId,
+    /// The user's ID.
+    pub user_id: UserId,
+    /// The ID of the user who created the membership.
+    pub sender: UserId,
+    /// The current membership state.
+    pub membership: String,
+}
+
+/// A new Matrix room membership, not yet saved.
+#[derive(Debug, Clone)]
+#[insertable_into(room_memberships)]
+pub struct NewRoomMembership {
+    /// The eventID.
+    pub event_id: EventId,
+    /// The room's ID.
+    pub room_id: RoomId,
+    /// The user's ID.
+    pub user_id: UserId,
+    /// The ID of the user who created the membership.
+    pub sender: UserId,
+    /// The current membership state.
+    pub membership: String,
+}
+
+/// A Matrix room membership.
+#[derive(Debug, Clone, Queryable)]
+#[changeset_for(room_memberships)]
+pub struct RoomMembership {
+    /// The eventID.
+    pub event_id: EventId,
+    /// The room's ID.
+    pub room_id: RoomId,
+    /// The user's ID.
+    pub user_id: UserId,
+    /// The ID of the user who created the membership.
+    pub sender: UserId,
+    /// The current membership state.
+    pub membership: String,
+    /// The time the room was created.
+    pub created_at: PgTimestamp,
+}
+
+impl RoomMembership {
+    /// Creates a new room membership in the database.
+    pub fn create(connection: &PgConnection,
+                  homeserver_domain: &str,
+                  room_membership_options: RoomMembershipOptions)
+                  -> Result<RoomMembership, ApiError> {
+        connection.transaction::<RoomMembership, ApiError, _>(|| {
+            let room_membership = RoomMembership::find(connection, room_membership_options.clone().room_id, room_membership_options.clone().user_id)?;
+
+            let join_rules_event = Event::find_room_join_rules_by_room_id(&connection, room_membership_options.clone().room_id)?;
+
+            match room_membership {
+                Some(room_membership) => {
+                    if room_membership.membership == room_membership_options.membership {
+                        return Err(ApiError::limited_rate(Some("Try to set the membership again!")));
+                    }
+
+                    Ok(room_membership)
+                },
+                None => {
+                    if join_rules_event.content.join_rule == JoinRule::Invite  {
+                        return Err(ApiError::unauthorized(Some("You are not invited to this room.")));
+                    }
+                    let event_id = EventId::new(&homeserver_domain).map_err(ApiError::from)?;
+                    let new_room_membership = NewRoomMembership {
+                        event_id: event_id.clone(),
+                        room_id: room_membership_options.clone().room_id,
+                        user_id: room_membership_options.clone().user_id,
+                        sender: room_membership_options.clone().sender,
+                        membership: room_membership_options.clone().membership,
+                    };
+
+                    let membership_string = Value::String(new_room_membership.clone().membership);
+                    let membership: MembershipState = from_value(membership_string)?;
+
+                    let new_memberstate_event: NewEvent = MemberEvent {
+                        content: MemberEventContent {
+                            avatar_url: None,
+                            displayname: None,
+                            membership: membership,
+                            third_party_invite: (),
+                        },
+                        event_id: event_id.clone(),
+                        event_type: EventType::RoomMember,
+                        extra_content: MemberEventExtraContent { invite_room_state: None },
+                        prev_content: None,
+                        room_id: room_membership_options.clone().room_id,
+                        state_key: "".to_string(),
+                        unsigned: None,
+                        user_id: room_membership_options.clone().user_id,
+                    }.try_into()?;
+
+                    insert(&new_memberstate_event).into(events::table)
+                        .execute(connection)
+                        .map_err(ApiError::from)?;
+
+                    let room_membership: RoomMembership =
+                    insert(&new_room_membership).into(room_memberships::table)
+                        .get_result(connection)
+                        .map_err(ApiError::from)?;
+                    Ok(room_membership)
+                }
+            }
+
+        }).map_err(ApiError::from)
+    }
+
+    /// Return `RoomMembership` for given `RoomId` and `UserId`.
+    pub fn find(connection: &PgConnection, room_id: RoomId, user_id: UserId) -> Result<Option<RoomMembership>,ApiError> {
+        let membership = room_memberships::table
+            .filter(room_memberships::room_id.eq(room_id))
+            .filter(room_memberships::user_id.eq(user_id))
+            .first(connection);
+        match membership {
+            Ok(membership) => Ok(Some(membership)),
+            Err(DieselError::NotFound) => Ok(None),
+            Err(err) => Err(ApiError::from(err)),
+        }
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -60,6 +60,17 @@ table! {
 }
 
 table! {
+    room_memberships (event_id) {
+        event_id -> Text,
+        room_id -> Text,
+        user_id -> Text,
+        sender -> Text,
+        membership -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+table! {
     account_data {
         id -> BigSerial,
         user_id -> Text,

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,7 @@ use api::r0::{
     DeactivateAccount,
     DeleteRoomAlias,
     GetRoomAlias,
+    JoinRoom,
     Login,
     Logout,
     PutAccountData,
@@ -76,6 +77,7 @@ impl<'a> Server<'a> {
             "/rooms/:room_id/state/:event_type/:state_key",
             StateMessageEvent::chain(),
         );
+        r0_router.post("/rooms/:room_id/join", JoinRoom::chain());
 
         let mut r0 = Chain::new(r0_router);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -181,6 +181,28 @@ impl Test {
             .unwrap()
             .to_string()
     }
+
+    /// Creates a room and returns the room ID as a string.
+    pub fn create_public_room(&self, access_token: &str) -> String {
+        self.post(&format!("/_matrix/client/r0/createRoom?access_token={}", access_token), r#"{"visibility": "public"}"#)
+            .json()
+            .find("room_id")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    /// Creates a room and returns the room ID as a string.
+    pub fn create_private_room(&self, access_token: &str) -> String {
+        self.post(&format!("/_matrix/client/r0/createRoom?access_token={}", access_token), r#"{"visibility": "private"}"#)
+            .json()
+            .find("room_id")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
 }
 
 impl Response {


### PR DESCRIPTION
Todo
- [x] Rate-limited check
- [x] The room is invite-only and the user was not invited. (Partial, Invite need to be done in different PR. Could be done later after adding invite api)
- [x] The user has been banned from the room.
