### PR TITLE
Add basic implementation for local invites

### DIFF
--- a/migrations/001_prerelease/up.sql
+++ b/migrations/001_prerelease/up.sql
@@ -52,9 +52,8 @@ CREATE TABLE room_account_data (
     UNIQUE (user_id, room_id, data_type)
 );
 
-CREATE TABLE room_memberships(
-    id BIGSERIAL PRIMARY KEY,
-    event_id TEXT NOT NULL,
+CREATE TABLE room_memberships (
+    event_id TEXT NOT NULL PRIMARY KEY,
     room_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
     sender TEXT NOT NULL,

--- a/migrations/001_prerelease/up.sql
+++ b/migrations/001_prerelease/up.sql
@@ -53,7 +53,8 @@ CREATE TABLE room_account_data (
 );
 
 CREATE TABLE room_memberships(
-    event_id TEXT NOT NULL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL,
     room_id TEXT NOT NULL,
     user_id TEXT NOT NULL,
     sender TEXT NOT NULL,

--- a/src/api/r0/account.rs
+++ b/src/api/r0/account.rs
@@ -117,10 +117,9 @@ impl Handler for PutAccountData {
         let user_id = request.extensions.get::<UserIdParam>()
             .expect("UserIdParam should ensure a UserId").clone();
 
-        // Check if the given user_id corresponds to the authenticated user.
         if user_id != user.id {
-            let error = ApiError::not_found(
-                Some(&format!("No user found with ID {}", user_id))
+            let error = ApiError::unauthorized(
+                Some("The given user_id does not correspond to the authenticated user")
             );
 
             return Err(IronError::new(error.clone(), error));
@@ -140,7 +139,7 @@ impl Handler for PutAccountData {
 
         let new_data = NewAccountData {
             user_id: user.id,
-            data_type: String::from(data_type),
+            data_type: data_type.to_string(),
             content: content,
         };
 
@@ -167,10 +166,9 @@ impl Handler for PutRoomAccountData {
         let user_id = request.extensions.get::<UserIdParam>()
             .expect("UserIdParam should ensure a UserId").clone();
 
-        // Check if the given user_id corresponds to the authenticated user.
         if user_id != user.id {
-            let error = ApiError::not_found(
-                Some(&format!("No user found with ID: {}", user_id))
+            let error = ApiError::unauthorized(
+                Some("The given user_id does not correspond to the authenticated user")
             );
 
             return Err(IronError::new(error.clone(), error));
@@ -214,7 +212,7 @@ impl Handler for PutRoomAccountData {
         let new_data = NewRoomAccountData {
             user_id: user.id,
             room_id: room_id,
-            data_type: String::from(data_type),
+            data_type: data_type.to_string(),
             content: content,
         };
 
@@ -336,7 +334,7 @@ mod tests {
 
         assert_eq!(
             test.put(&account_data_path, &content).status,
-            Status::NotFound
+            Status::Forbidden
         );
     }
 
@@ -380,11 +378,11 @@ mod tests {
 
         assert_eq!(test.join_room(&access_token, &room_id).status, Status::Ok);
 
-        assert_eq!(test.put(&path, &content).status, Status::NotFound);
+        assert_eq!(test.put(&path, &content).status, Status::Forbidden);
 
         assert_eq!(
             test.put(&path, &content).json().find("error").unwrap().as_str().unwrap(),
-            format!("No user found with ID: {}", user_id)
+            "The given user_id does not correspond to the authenticated user"
         );
     }
 

--- a/src/api/r0/join.rs
+++ b/src/api/r0/join.rs
@@ -1,12 +1,19 @@
 //! Endpoints for joining rooms.
 
-use iron::{Chain, Handler, IronResult, Request, Response};
+use std::convert::TryFrom;
+use std::error::Error;
+
+use bodyparser;
 use iron::status::Status;
+use iron::{Chain, Handler, IronError, IronResult, Plugin, Request, Response};
+use ruma_identifiers::UserId;
 
 use config::Config;
 use db::DB;
+use error::{ApiError, MapApiError};
 use middleware::{AccessTokenAuth, JsonRequest, MiddlewareChain, RoomIdParam};
 use modifier::SerializableResponse;
+use room::Room;
 use room_membership::{RoomMembership, RoomMembershipOptions};
 use user::User;
 
@@ -38,10 +45,10 @@ impl Handler for JoinRoom {
             room_id: room_id.clone(),
             user_id: user.id.clone(),
             sender: user.id,
-            membership: String::from("join"),
+            membership: "join".to_string(),
         };
 
-        let room_membership = RoomMembership::create(
+        let room_membership = RoomMembership::upsert(
             &connection,
             &config.domain,
             room_membership_options
@@ -52,6 +59,101 @@ impl Handler for JoinRoom {
         Ok(Response::with((Status::Ok, SerializableResponse(response))))
     }
 }
+
+/// The `/rooms/:room_id/invite` endpoint.
+#[derive(Debug)]
+pub struct InviteToRoom;
+
+#[derive(Clone, Debug, Deserialize)]
+struct InviteToRoomRequest {
+    pub user_id: String,
+}
+
+middleware_chain!(InviteToRoom, [JsonRequest, RoomIdParam, AccessTokenAuth]);
+
+impl Handler for InviteToRoom {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let room_id = request.extensions.get::<RoomIdParam>()
+            .expect("RoomIdParam should ensure a room_id").clone();
+
+        let inviter = request.extensions.get::<User>()
+            .expect("AccessTokenAuth should ensure a user").clone();
+
+        let invitee_id = match request.get::<bodyparser::Struct<InviteToRoomRequest>>() {
+            Ok(Some(req)) => UserId::try_from(&req.user_id).map_api_err(|err| {
+                ApiError::invalid_param("user_id", err.description())
+            }),
+            Ok(None) | Err(_) => Err(ApiError::missing_param("user_id"))
+        }?;
+
+        let connection = DB::from_request(request)?;
+        let config = Config::from_request(request)?;
+
+        // Check if the invitee exists.
+        User::find_by_uid(&connection, &invitee_id)
+            .map_err(IronError::from)?;
+
+        // Check if the room exists.
+        Room::find(&connection, &room_id)
+            .map_err(IronError::from)?;
+
+        // Check if the inviter has joined the room.
+        let unauthorized_err = ApiError::unauthorized(
+            Some("The inviter hasn't joined the room yet")
+        );
+
+        RoomMembership::find(&connection, &room_id, &inviter.id)
+            .and_then(|membership| match membership {
+                Some(entry) => match entry.membership.as_ref() {
+                    "join" => Ok(()),
+                    _ => Err(unauthorized_err)
+                },
+                None => Err(unauthorized_err)
+            })?;
+
+        let invitee_membership = RoomMembership::find(&connection, &room_id, &invitee_id)?;
+        let new_membership_options = RoomMembershipOptions {
+            room_id: room_id,
+            user_id: invitee_id,
+            sender: inviter.id,
+            membership: "invite".to_string(),
+        };
+
+        match invitee_membership {
+            Some(mut entry) => match entry.membership.as_ref() {
+                "invite" => Ok(()),
+                "ban" => Err(ApiError::unauthorized(
+                    Some("The invited user is banned from the room")
+                )),
+                "join" => Err(ApiError::unauthorized(
+                    Some("The invited user has already joined")
+                )),
+                _ => {
+                    entry.update(
+                        &connection,
+                        &config.domain,
+                        new_membership_options
+                    )?;
+
+                    Ok(())
+                }
+            },
+            None => {
+                RoomMembership::create(
+                    &connection,
+                    &config.domain,
+                    new_membership_options
+                )?;
+
+                Ok(())
+            }
+        }?;
+
+        Ok(Response::with(Status::Ok))
+    }
+}
+
+
 
 #[cfg(test)]
 mod tests {
@@ -131,6 +233,174 @@ mod tests {
 
         let response = test.post(&room_join_path, r"{}");
 
+        assert_eq!(response.status, Status::Ok);
         assert!(response.json().find("room_id").unwrap().as_str().is_some());
+    }
+
+    #[test]
+    fn join_other_private_room_without_invite() {
+        let test = Test::new();
+        let bob_token = test.create_access_token_with_username("bob");
+        let alice_token = test.create_access_token_with_username("alice");
+
+        let room_id = test.create_private_room(&bob_token);
+
+        let room_join_path = format!(
+            "/_matrix/client/r0/rooms/{}/join?access_token={}",
+            room_id,
+            alice_token
+        );
+
+        let response = test.post(&room_join_path, r"{}");
+
+        assert_eq!(response.status, Status::Forbidden);
+    }
+
+    #[test]
+    fn invite_to_room() {
+        let test = Test::new();
+        let bob_token = test.create_access_token_with_username("bob");
+        let alice_token = test.create_access_token_with_username("alice");
+
+        let room_id = test.create_private_room(&bob_token);
+
+        let response = test.invite(&bob_token, &room_id, "@alice:ruma.test");
+
+        assert_eq!(response.status, Status::Ok);
+
+        assert!(test.join_room(&alice_token, &room_id).status.is_success());
+    }
+
+    #[test]
+    fn invite_before_joining() {
+        let test = Test::new();
+
+        let carl_token = test.create_access_token_with_username("carl");
+        let bob_token = test.create_access_token_with_username("bob");
+        let _ = test.create_access_token_with_username("alice");
+
+        // Carl invites Bob.
+        let body = r#"{"visibility": "private", "invite": ["@bob:ruma.test"]}"#;
+        let room_id = test.create_room_with_params(&carl_token, body);
+
+        // Bob invites Alice before joining.
+        let response = test.invite(&bob_token, &room_id, "@alice:ruma.test");
+
+        assert_eq!(response.status, Status::Forbidden);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The inviter hasn't joined the room yet"
+        );
+    }
+
+    #[test]
+    fn invite_without_user_id() {
+        let test = Test::new();
+        let carl_token = test.create_access_token_with_username("carl");
+
+        let room_id = test.create_private_room(&carl_token);
+        let invite_path = format!(
+            "/_matrix/client/r0/rooms/{}/invite?access_token={}",
+            room_id,
+            carl_token
+        );
+
+        // Empty body.
+        let response = test.post(&invite_path, "{}");
+
+        assert_eq!(response.status, Status::BadRequest);
+        assert_eq!(
+            response.json().find("errcode").unwrap().as_str().unwrap(),
+            "M_MISSING_PARAM"
+        );
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "Missing value for required parameter: user_id."
+        );
+    }
+
+    #[test]
+    fn invitee_does_not_exist() {
+        let test = Test::new();
+        let carl_token = test.create_access_token_with_username("carl");
+
+        let room_id = test.create_private_room(&carl_token);
+
+        // User 'mark' does not exist.
+        let response = test.invite(&carl_token, &room_id, "@mark:ruma.test");
+
+        assert_eq!(response.status, Status::NotFound);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The user @mark:ruma.test was not found on this server"
+        );
+    }
+
+    #[test]
+    fn invitee_is_invalid() {
+        let test = Test::new();
+        let carl_token = test.create_access_token();
+        let room_id = test.create_private_room(&carl_token);
+
+        let response = test.invite(&carl_token, &room_id, "mark.ruma.test");
+
+        assert_eq!(response.status, Status::BadRequest);
+        assert_eq!(
+            response.json().find("errcode").unwrap().as_str().unwrap(),
+            "IO_RUMA_INVALID_PARAM"
+        );
+    }
+
+    #[test]
+    fn invitee_is_already_invited() {
+        let test = Test::new();
+        let bob_token = test.create_access_token_with_username("bob");
+        let _ = test.create_access_token_with_username("alice");
+
+        let room_id = test.create_room_with_params(
+            &bob_token,
+            r#"{"visibility": "private", "invite": ["@alice:ruma.test"]}"#
+        );
+
+        let response = test.invite(&bob_token, &room_id, "@alice:ruma.test");
+
+        assert_eq!(response.status, Status::Ok);
+    }
+
+    #[test]
+    fn invitee_has_already_joined() {
+        let test = Test::new();
+        let bob_token = test.create_access_token_with_username("bob");
+        let alice_token = test.create_access_token_with_username("alice");
+
+        let room_id = test.create_room_with_params(
+            &bob_token,
+            r#"{"visibility": "private", "invite": ["@alice:ruma.test"]}"#
+        );
+
+        assert!(test.join_room(&alice_token, &room_id).status.is_success());
+
+        let response = test.invite(&bob_token, &room_id, "@alice:ruma.test");
+
+        assert_eq!(response.status, Status::Forbidden);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The invited user has already joined"
+        );
+    }
+
+    #[test]
+    fn room_does_not_exist() {
+        let test = Test::new();
+        let bob_token = test.create_access_token_with_username("bob");
+        let _ = test.create_access_token_with_username("alice");
+
+        let response = test.invite(&bob_token, "!random:ruma.test", "@alice:ruma.test");
+
+        assert_eq!(response.status, Status::NotFound);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The room was not found on this server"
+        );
     }
 }

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -8,11 +8,11 @@ pub use self::account::{
 };
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
-pub use self::join::JoinRoom;
+pub use self::join::{InviteToRoom, JoinRoom};
 pub use self::login::Login;
 pub use self::logout::Logout;
 pub use self::members::Members;
-pub use self::profile::{Profile, GetAvatarUrl, PutAvatarUrl, GetDisplayname, PutDisplayname};
+pub use self::profile::{Profile, GetAvatarUrl, PutAvatarUrl, GetDisplayName, PutDisplayName};
 pub use self::registration::Register;
 pub use self::room_creation::CreateRoom;
 pub use self::versions::Versions;

--- a/src/api/r0/profile.rs
+++ b/src/api/r0/profile.rs
@@ -33,7 +33,7 @@ impl Handler for Profile {
 
         let connection = DB::from_request(request)?;
 
-        let profile = DataProfile::find_by_user_id(&connection, user_id.clone())?;
+        let profile = DataProfile::find_by_uid(&connection, user_id.clone())?;
 
         let response = match profile {
             Some(profile) => {
@@ -44,7 +44,7 @@ impl Handler for Profile {
             }
             None => {
                 let error = ApiError::not_found(
-                    Some(&format!("No displayname found with ID {}", user_id))
+                    Some(&format!("No profile found for {}", user_id))
                 );
 
                 return Err(IronError::new(error.clone(), error));
@@ -75,7 +75,7 @@ impl Handler for GetAvatarUrl {
 
         let connection = DB::from_request(request)?;
 
-        let profile = DataProfile::find_by_user_id(&connection, user_id.clone())?;
+        let profile = DataProfile::find_by_uid(&connection, user_id.clone())?;
 
         let response = match profile {
             Some(profile) => {
@@ -87,7 +87,7 @@ impl Handler for GetAvatarUrl {
                     },
                     None => {
                         let error = ApiError::not_found(
-                            Some(&format!("No displayname found with ID {}", user_id))
+                            Some(&format!("No avatar_url found for {}", user_id))
                         );
 
                         return Err(IronError::new(error.clone(), error));
@@ -96,7 +96,7 @@ impl Handler for GetAvatarUrl {
             }
             None => {
                 let error = ApiError::not_found(
-                    Some(&format!("No displayname found with ID {}", user_id))
+                    Some(&format!("No profile found for {}", user_id))
                 );
 
                 return Err(IronError::new(error.clone(), error));
@@ -137,32 +137,37 @@ impl Handler for PutAvatarUrl {
         let user_id = request.extensions.get::<UserIdParam>()
             .expect("UserIdParam should ensure a UserId").clone();
 
-        // Check if the given user_id corresponds to the authenticated user.
         if user_id != user.id {
-            let error = ApiError::limited_rate(
-                Some(&format!("No user found with ID {}", user_id))
+            let error = ApiError::unauthorized(
+                Some("The given user_id does not correspond to the authenticated user")
             );
 
             return Err(IronError::new(error.clone(), error));
         }
 
-        DataProfile::update_avatar_url(&connection, &config.domain, user_id, avatar_url_request.avatar_url)?;
+        DataProfile::update_avatar_url(
+            &connection,
+            user_id.clone(),
+            avatar_url_request.avatar_url
+        )?;
+
+        DataProfile::update_memberships(&connection, &config.domain, user_id.clone())?;
 
         Ok(Response::with(Status::Ok))
     }
 }
 
 /// The `/profile/:user_id/displayname` endpoint.
-pub struct GetDisplayname;
+pub struct GetDisplayName;
 
 #[derive(Clone, Debug, Serialize)]
-struct GetDisplaynameResponse {
+struct GetDisplayNameResponse {
     displayname: String,
 }
 
-middleware_chain!(GetDisplayname, [UserIdParam, AccessTokenAuth]);
+middleware_chain!(GetDisplayName, [UserIdParam, AccessTokenAuth]);
 
-impl Handler for GetDisplayname {
+impl Handler for GetDisplayName {
     fn handle(&self, request: &mut Request) -> IronResult<Response> {
         request.extensions.get::<User>()
             .expect("AccessTokenAuth should ensure a user").clone();
@@ -172,19 +177,19 @@ impl Handler for GetDisplayname {
 
         let connection = DB::from_request(request)?;
 
-        let profile = DataProfile::find_by_user_id(&connection, user_id.clone())?;
+        let profile = DataProfile::find_by_uid(&connection, user_id.clone())?;
 
         let response = match profile {
             Some(profile) => {
                 match profile.displayname {
                     Some(displayname) => {
-                        GetDisplaynameResponse {
+                        GetDisplayNameResponse {
                             displayname: displayname,
                         }
                     },
                     None => {
                         let error = ApiError::not_found(
-                            Some(&format!("No displayname found with ID {}", user_id))
+                            Some(&format!("No displayname found for {}", user_id))
                         );
 
                         return Err(IronError::new(error.clone(), error));
@@ -193,7 +198,7 @@ impl Handler for GetDisplayname {
             }
             None => {
                 let error = ApiError::not_found(
-                    Some(&format!("No displayname found with ID {}", user_id))
+                    Some(&format!("No profile found for {}", user_id))
                 );
 
                 return Err(IronError::new(error.clone(), error));
@@ -205,18 +210,18 @@ impl Handler for GetDisplayname {
 }
 
 /// The `/profile/:user_id/displayname` endpoint.
-pub struct PutDisplayname;
+pub struct PutDisplayName;
 
 #[derive(Clone, Debug, Deserialize)]
-struct PutDisplaynameResquest {
+struct PutDisplayNameRequest {
     displayname: Option<String>,
 }
 
-middleware_chain!(PutDisplayname, [JsonRequest, UserIdParam, AccessTokenAuth]);
+middleware_chain!(PutDisplayName, [JsonRequest, UserIdParam, AccessTokenAuth]);
 
-impl Handler for PutDisplayname {
+impl Handler for PutDisplayName {
     fn handle(&self, request: &mut Request) -> IronResult<Response> {
-        let displayname_request = match request.get::<bodyparser::Struct<PutDisplaynameResquest>>() {
+        let displayname_request = match request.get::<bodyparser::Struct<PutDisplayNameRequest>>() {
             Ok(Some(displayname_request)) => displayname_request,
             Ok(None) | Err(_) => {
                 let error = ApiError::bad_json(None);
@@ -234,16 +239,21 @@ impl Handler for PutDisplayname {
         let user_id = request.extensions.get::<UserIdParam>()
             .expect("UserIdParam should ensure a UserId").clone();
 
-        // Check if the given user_id corresponds to the authenticated user.
         if user_id != user.id {
-            let error = ApiError::limited_rate(
-                Some(&format!("No user found with ID {}", user_id))
+            let error = ApiError::unauthorized(
+                Some("The given user_id does not correspond to the authenticated user")
             );
 
             return Err(IronError::new(error.clone(), error));
         }
 
-        DataProfile::update_displayname(&connection, &config.domain, user_id, displayname_request.displayname)?;
+        DataProfile::update_displayname(
+            &connection,
+            user_id.clone(),
+            displayname_request.displayname
+        )?;
+
+        DataProfile::update_memberships(&connection, &config.domain, user_id.clone())?;
 
         Ok(Response::with(Status::Ok))
     }
@@ -256,7 +266,7 @@ mod tests {
     use iron::status::Status;
 
     #[test]
-    fn get_displayname_not_set() {
+    fn get_displayname_non_existent_user() {
         let test = Test::new();
         let access_token = test.create_access_token();
         let user_id = "@carls:ruma.test";
@@ -266,14 +276,18 @@ mod tests {
             user_id,
             access_token
         );
+
+        let response = test.get(&get_displayname_path);
+
+        assert_eq!(response.status, Status::NotFound);
         assert_eq!(
-            test.get(&get_displayname_path).status,
-            Status::NotFound
+            response.json().find("error").unwrap().as_str().unwrap(),
+            format!("No profile found for {}", user_id)
         );
     }
 
     #[test]
-    fn get_avatar_url_not_set() {
+    fn get_avatar_url_non_existent_user() {
         let test = Test::new();
         let access_token = test.create_access_token();
         let user_id = "@carls:ruma.test";
@@ -283,9 +297,13 @@ mod tests {
             user_id,
             access_token
         );
+
+        let response = test.get(&get_avatar_url);
+
+        assert_eq!(response.status, Status::NotFound);
         assert_eq!(
-            test.get(&get_avatar_url).status,
-            Status::NotFound
+            response.json().find("error").unwrap().as_str().unwrap(),
+            format!("No profile found for {}", user_id)
         );
     }
 
@@ -346,39 +364,94 @@ mod tests {
     }
 
     #[test]
-    fn put_displayname_rated_limted() {
+    fn put_displayname_unauthorized() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let user_id = "@carls:ruma.test";
+        let bob_token = test.create_access_token_with_username("bob");
+        let _ = test.create_access_token_with_username("alice");
 
         let put_displayname = format!(
             "/_matrix/client/r0/profile/{}/displayname?access_token={}",
-            user_id,
-            access_token,
+            "@alice:ruma.test",
+            bob_token,
         );
-        let response = test.put(&put_displayname, r#"{"displayname": "Bogus"}"#);
 
-        assert_eq!(response.status, Status::TooManyRequests);
+        let response = test.put(&put_displayname, r#"{"displayname": "Alice"}"#);
+
+        assert_eq!(response.status, Status::Forbidden);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The given user_id does not correspond to the authenticated user"
+        );
     }
 
     #[test]
-    fn put_avatar_url_rated_limted() {
+    fn put_avatar_url_unauthorized() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let user_id = "@carls:ruma.test";
+        let bob_token = test.create_access_token_with_username("bob");
+        let _ = test.create_access_token_with_username("alice");
 
         let put_avatar_url = format!(
             "/_matrix/client/r0/profile/{}/avatar_url?access_token={}",
-            user_id,
-            access_token,
+            "@alice:ruma.test",
+            bob_token,
         );
-        let response = test.put(&put_avatar_url, r#"{"avatar_url": "mxc://matrix.org/wefh34uihSDRGhw34"}"#);
 
-        assert_eq!(response.status, Status::TooManyRequests);
+        let response = test.put(
+            &put_avatar_url,
+            r#"{"avatar_url": "mxc://matrix.org/wefh34uihSDRGhw34"}"#
+        );
+
+        assert_eq!(response.status, Status::Forbidden);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            "The given user_id does not correspond to the authenticated user"
+        );
     }
 
     #[test]
-    fn get_profile_not_set() {
+    fn get_profile() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+
+        let avatar_url_body = r#"{"avatar_url": "mxc://matrix.org/some/url"}"#;
+        let avatar_url_path = format!(
+            "/_matrix/client/r0/profile/{}/avatar_url?access_token={}",
+            "@carl:ruma.test",
+            access_token
+        );
+
+        assert!(test.put(&avatar_url_path, avatar_url_body).status.is_success());
+
+        let displayname_body = r#"{"displayname": "Carl"}"#;
+        let displayname_path = format!(
+            "/_matrix/client/r0/profile/{}/displayname?access_token={}",
+            "@carl:ruma.test",
+            access_token
+        );
+
+        assert!(test.put(&displayname_path, displayname_body).status.is_success());
+
+        let profile_path = format!(
+            "/_matrix/client/r0/profile/{}?access_token={}",
+            "@carl:ruma.test",
+            access_token
+        );
+
+        let response = test.get(&profile_path);
+
+        assert_eq!(response.status, Status::Ok);
+        assert_eq!(
+            response.json().find("avatar_url").unwrap().as_str().unwrap(),
+            "mxc://matrix.org/some/url"
+        );
+        assert_eq!(
+            response.json().find("displayname").unwrap().as_str().unwrap(),
+            "Carl"
+        );
+    }
+
+    #[test]
+    fn get_profile_non_existent_user() {
         let test = Test::new();
         let access_token = test.create_access_token();
         let user_id = "@carls:ruma.test";
@@ -388,8 +461,13 @@ mod tests {
             user_id,
             access_token,
         );
+
         let response = test.get(&get_profile);
 
         assert_eq!(response.status, Status::NotFound);
+        assert_eq!(
+            response.json().find("error").unwrap().as_str().unwrap(),
+            format!("No profile found for {}", user_id)
+        );
     }
 }

--- a/src/api/r0/room_creation.rs
+++ b/src/api/r0/room_creation.rs
@@ -109,7 +109,7 @@ impl Handler for CreateRoom {
                 room_id: room.id.clone(),
                 user_id: room.user_id.clone(),
                 sender: room.user_id.clone(),
-                membership: String::from("join")
+                membership: "join".to_string(),
             };
 
             RoomMembership::create(&connection, &config.domain, options)

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -85,6 +85,6 @@ impl AuthParams {
     pub fn authenticate(&self, connection: &PgConnection) -> Result<User, ApiError> {
         let &AuthParams::Password(ref credentials) = self;
 
-        User::find_by_uid_and_password(connection, &credentials.user_id, &credentials.password)
+        User::verify(connection, &credentials.user_id, &credentials.password)
     }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -12,24 +12,13 @@ use diesel::result::Error as DieselError;
 use ruma_identifiers::UserId;
 
 use error::ApiError;
-use room_membership::RoomMembership;
+use room_membership::{RoomMembership, RoomMembershipOptions};
 use schema::profiles;
-
-/// A new Matrix profile, not yet saved.
-#[derive(Debug, Clone)]
-#[insertable_into(profiles)]
-pub struct NewProfile {
-    /// The user's ID.
-    pub id: UserId,
-    /// The avatar url.
-    pub avatar_url: Option<String>,
-    /// The display name.
-    pub displayname: Option<String>,
-}
 
 /// A Matrix profile.
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[changeset_for(profiles)]
+#[insertable_into(profiles)]
 pub struct Profile {
     /// The user's ID.
     pub id: UserId,
@@ -41,82 +30,86 @@ pub struct Profile {
 
 impl Profile {
     /// Update or Create a `Profile` entry with new avatar_url.
-    pub fn update_avatar_url(connection: &PgConnection, homeserver_domain: &str, user_id: UserId, avatar_url: Option<String>) -> Result<Profile, ApiError> {
-        let profile = Profile::find_by_user_id(connection, user_id.clone())?;
+    pub fn update_avatar_url(connection: &PgConnection, user_id: UserId, avatar_url: Option<String>)
+    -> Result<Profile, ApiError> {
+        let profile = Profile::find_by_uid(connection, user_id.clone())?;
 
-        let mut profile = match profile {
-            Some(mut profile) => {
-                profile.set_avatar_url(connection, avatar_url)?;
-                Ok(profile)
-            },
+        match profile {
+            Some(mut profile) => profile.set_avatar_url(connection, avatar_url),
             None => {
-                let new_profile = NewProfile {
+                let new_profile = Profile {
                     id: user_id.clone(),
                     avatar_url: avatar_url,
                     displayname: None,
                 };
+
                 Profile::create(connection, &new_profile)
             }
-        }?;
-        profile.update_events(connection, homeserver_domain, user_id)?;
-        Ok(profile)
+        }
     }
 
     /// Update or Create a `Profile` entry with new displayname.
-    pub fn update_displayname(connection: &PgConnection, homeserver_domain: &str, user_id: UserId, displayname: Option<String>) -> Result<Profile, ApiError> {
-        let profile = Profile::find_by_user_id(connection, user_id.clone())?;
+    pub fn update_displayname(connection: &PgConnection, user_id: UserId, displayname: Option<String>)
+    -> Result<Profile, ApiError> {
+        let profile = Profile::find_by_uid(connection, user_id.clone())?;
 
-        let mut profile = match profile {
-            Some(mut profile) => {
-                profile.set_displayname(connection, displayname)?;
-                Ok(profile)
-            },
+        match profile {
+            Some(mut profile) => profile.set_displayname(connection, displayname),
             None => {
-                let new_profile = NewProfile {
+                let new_profile = Profile {
                     id: user_id.clone(),
                     avatar_url: None,
                     displayname: displayname,
                 };
+
                 Profile::create(connection, &new_profile)
             }
-        }?;
-        profile.update_events(connection, homeserver_domain, user_id)?;
-        Ok(profile)
+        }
     }
 
     /// Update a `Profile` entry with new avatar_url.
     fn set_avatar_url(&mut self, connection: &PgConnection, avatar_url: Option<String>)
-        -> Result<(), ApiError> {
+    -> Result<Profile, ApiError> {
         self.avatar_url = avatar_url;
 
         match self.save_changes::<Profile>(connection) {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(self.clone()),
             Err(error) => Err(ApiError::from(error)),
         }
     }
 
     /// Update a `Profile` entry with new displayname.
     fn set_displayname(&mut self, connection: &PgConnection, displayname: Option<String>)
-        -> Result<(), ApiError> {
+    -> Result<Profile, ApiError> {
         self.displayname = displayname;
 
         match self.save_changes::<Profile>(connection) {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(self.clone()),
             Err(error) => Err(ApiError::from(error)),
         }
     }
 
-    /// Update `RoomMembership` due to changed `Profile`.
-    pub fn update_events(&mut self, connection: &PgConnection, homeserver_domain: &str, user_id: UserId) -> Result<(), ApiError> {
-        let mut room_memberships = RoomMembership::find_by_user_id(connection, user_id)?;
+    /// Update `RoomMembership`'s due to changed `Profile`.
+    pub fn update_memberships(connection: &PgConnection, homeserver_domain: &str, user_id: UserId)
+    -> Result<(), ApiError> {
+        let mut room_memberships = RoomMembership::find_by_uid(connection, user_id.clone())?;
+
         for room_membership in room_memberships.iter_mut() {
-            RoomMembership::update_room_membership_events(connection, homeserver_domain, room_membership, self.clone())?;
+            let options = RoomMembershipOptions {
+                room_id: room_membership.room_id.clone(),
+                user_id: user_id.clone(),
+                sender: user_id.clone(),
+                membership: "join".to_string(),
+            };
+
+            room_membership.update(connection, homeserver_domain, options)?;
         }
+
         Ok(())
     }
 
     /// Create a `Profile` entry.
-    pub fn create(connection: &PgConnection, new_profile: &NewProfile) -> Result<Profile, ApiError> {
+    pub fn create(connection: &PgConnection, new_profile: &Profile) -> Result<Profile, ApiError> {
         insert(new_profile)
             .into(profiles::table)
             .get_result(connection)
@@ -124,10 +117,11 @@ impl Profile {
     }
 
     /// Return `Profile` for given `UserId`.
-    pub fn find_by_user_id(connection: &PgConnection, user_id: UserId) -> Result<Option<Profile>, ApiError> {
+    pub fn find_by_uid(connection: &PgConnection, user_id: UserId) -> Result<Option<Profile>, ApiError> {
         let profile = profiles::table
             .filter(profiles::id.eq(user_id))
             .first(connection);
+
         match profile {
             Ok(profile) => Ok(Some(profile)),
             Err(DieselError::NotFound) => Ok(None),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,7 +58,8 @@ table! {
 }
 
 table! {
-    room_memberships (event_id) {
+    room_memberships {
+        id -> BigSerial,
         event_id -> Text,
         room_id -> Text,
         user_id -> Text,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,8 +58,7 @@ table! {
 }
 
 table! {
-    room_memberships {
-        id -> BigSerial,
+    room_memberships (event_id) {
         event_id -> Text,
         room_id -> Text,
         user_id -> Text,

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,8 +15,9 @@ use api::r0::{
     DeactivateAccount,
     DeleteRoomAlias,
     GetAvatarUrl,
-    GetDisplayname,
+    GetDisplayName,
     GetRoomAlias,
+    InviteToRoom,
     JoinRoom,
     Login,
     Logout,
@@ -24,7 +25,7 @@ use api::r0::{
     Profile,
     PutAccountData,
     PutAvatarUrl,
-    PutDisplayname,
+    PutDisplayName,
     PutRoomAccountData,
     PutRoomAlias,
     Register,
@@ -86,12 +87,13 @@ impl<'a> Server<'a> {
             StateMessageEvent::chain(),
         );
         r0_router.post("/rooms/:room_id/join", JoinRoom::chain());
+        r0_router.post("/rooms/:room_id/invite", InviteToRoom::chain());
         r0_router.get("/rooms/:room_id/members", Members::chain());
         r0_router.get("/profile/:user_id", Profile::chain());
         r0_router.get("/profile/:user_id/avatar_url", GetAvatarUrl::chain());
-        r0_router.get("/profile/:user_id/displayname", GetDisplayname::chain());
+        r0_router.get("/profile/:user_id/displayname", GetDisplayName::chain());
         r0_router.put("/profile/:user_id/avatar_url", PutAvatarUrl::chain());
-        r0_router.put("/profile/:user_id/displayname", PutDisplayname::chain());
+        r0_router.put("/profile/:user_id/displayname", PutDisplayName::chain());
 
         let mut r0 = Chain::new(r0_router);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -197,6 +197,18 @@ impl Test {
         self.create_room_with_params(access_token, r#"{"visibility": "private"}"#)
     }
 
+    /// Invite a `User` to a `Room`.
+    pub fn invite(&self, access_token: &str, room_id: &str, invitee_id: &str) -> Response {
+        let body = format!(r#"{{"user_id": "{}"}}"#, invitee_id);
+        let path = format!(
+            "/_matrix/client/r0/rooms/{}/invite?access_token={}",
+            room_id,
+            access_token
+        );
+
+        self.post(&path, &body)
+    }
+
     /// Join an existent room.
     pub fn join_room(&self, access_token: &str, room_id: &str) -> Response {
         let join_path = format!(


### PR DESCRIPTION
- Fixed a bug on `RoomMembership::create` where only memberships
  with the same user_id and sender could be created, on invite-only rooms.
- The `Join` endpoint was refactored to update an existing `RoomMembership`
  (e.g join after an invite).
- A new `MemberEvent` is created when a `RoomMembership` update occurs.
- `RoomMemberships` for invited users are created when a new room is created.
- Removed duplicated `MemberEvent` generation from Room into its own
  function in `RoomMembership`.

Most of the changes occurred while implementing the invite endpoint, so I included
them in this PR. 

Apparently diesel needs an `id` field when you derive the `Identifiable` trait. Let me know 
if there is a workaround.
