### PR TITLE
Add partial implementation for the sync endpoint.

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -102,7 +102,7 @@ Legend:
     <th align="left" colspan="3">Syncing events</th>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:construction:</td>
     <td><a href="https://github.com/ruma/ruma/issues/8">#8</a></td>
     <td>GET /sync</td>
   </tr>

--- a/migrations/001_prerelease/up.sql
+++ b/migrations/001_prerelease/up.sql
@@ -24,7 +24,8 @@ CREATE TABLE events (
   state_key TEXT,
   content TEXT NOT NULL,
   extra_content TEXT,
-  created_at TIMESTAMP NOT NULL DEFAULT now()
+  created_at TIMESTAMP NOT NULL DEFAULT now(),
+  UNIQUE (ordering)
 );
 
 CREATE TABLE profiles (

--- a/src/api/r0/directory.rs
+++ b/src/api/r0/directory.rs
@@ -207,8 +207,7 @@ mod tests {
     #[test]
     fn put_room_alias() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let room_id = test.create_room(&access_token);
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
 
         let put_room_alias_path = format!(
             "/_matrix/client/r0/directory/room/my_room?access_token={}", access_token

--- a/src/api/r0/event_creation.rs
+++ b/src/api/r0/event_creation.rs
@@ -103,7 +103,7 @@ impl Handler for SendMessageEvent {
         let event_type = request.extensions.get::<EventTypeParam>()
             .expect("EventTypeParam should ensure an EventType").clone();
 
-        let transaction_id = request.extensions.get::<TransactionIdParam>()
+        request.extensions.get::<TransactionIdParam>()
             .expect("TransactionIdParam should ensure a TransactionId").clone();
 
         let user = request.extensions.get::<User>()

--- a/src/api/r0/filter.rs
+++ b/src/api/r0/filter.rs
@@ -2,184 +2,15 @@
 use bodyparser;
 use iron::{Chain, Handler, IronError, IronResult, Plugin, Request, Response};
 use iron::status::Status;
-use ruma_identifiers::{RoomId, UserId};
 use serde_json::de::from_str;
 use serde_json::value::ToJson;
 
 use db::DB;
 use error::ApiError;
 use middleware::{AccessTokenAuth, FilterIdParam, JsonRequest, MiddlewareChain, UserIdParam};
-use models::filter::{Filter as DataFilter};
+use models::filter::{Filter, ContentFilter};
 use models::user::User;
 use modifier::SerializableResponse;
-
-/// Filter
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Filter {
-    /// A list of event types to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub not_types: Vec<String>,
-    /// The maximum number of events to return.
-    pub limit: usize,
-    /// A list of senders IDs to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_user_id")]
-    pub senders: Vec<UserId>,
-    /// A list of event types to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub types: Vec<String>,
-    /// A list of sender IDs to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_user_id")]
-    pub not_senders: Vec<UserId>,
-}
-
-/// RoomEventFilter
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RoomEventFilter {
-    /// A list of event types to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub not_types: Vec<String>,
-    /// A list of event types to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub types: Vec<String>,
-    /// A list of room IDs to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_room_id")]
-    pub not_rooms: Vec<RoomId>,
-    /// A list of room IDs to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_room_id")]
-    pub rooms: Vec<RoomId>,
-    /// The maximum number of events to return.
-    pub limit: usize,
-    /// A list of sender IDs to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_user_id")]
-    pub not_senders: Vec<UserId>,
-    /// A list of senders IDs to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_user_id")]
-    pub senders: Vec<UserId>,
-}
-
-fn default_include_leave() -> bool {
-    false
-}
-
-fn default_vec_room_id() -> Vec<RoomId> {
-    Vec::new()
-}
-
-fn default_vec_user_id() -> Vec<UserId> {
-    Vec::new()
-}
-
-fn is_false(test: &bool) -> bool {
-    !test
-}
-
-
-/// RoomFilter
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RoomFilter {
-    /// Include rooms that the user has left in the sync, default false
-    #[serde(default = "default_include_leave")]
-    #[serde(skip_serializing_if = "is_false")]
-    pub include_leave: bool,
-    /// The per user account data to include for rooms.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_data: Option<RoomEventFilter>,
-    /// The message and state update events to include for rooms.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timeline: Option<RoomEventFilter>,
-    /// The events that aren't recorded in the room history, e.g. typing and receipts, to include for rooms.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ephemeral: Option<RoomEventFilter>,
-    /// The state events to include for rooms.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<RoomEventFilter>,
-    /// A list of room IDs to exclude.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_room_id")]
-    pub not_rooms: Vec<RoomId>,
-    /// A list of room IDs to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default = "default_vec_room_id")]
-    pub rooms: Vec<RoomId>,
-}
-
-/// EventFormat
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum EventFormat {
-    /// 'client' will return the events in a format suitable for clients.
-    Client,
-    /// 'federation' will return the raw event as receieved over federation.
-    Federation,
-}
-
-impl ::serde::Serialize for EventFormat {
-    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
-        where S: ::serde::Serializer,
-    {
-        // Serialize the enum as a string.
-        serializer.serialize_str(match *self {
-            EventFormat::Client => "client",
-            EventFormat::Federation => "federation",
-        })
-    }
-}
-
-impl ::serde::Deserialize for EventFormat {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
-        where D: ::serde::Deserializer,
-    {
-        struct Visitor;
-
-        impl ::serde::de::Visitor for Visitor {
-            type Value = EventFormat;
-
-            fn visit_str<E>(&mut self, value: &str) -> Result<EventFormat, E>
-                where E: ::serde::de::Error,
-            {
-                match value {
-                    "client" => Ok(EventFormat::Client),
-                    "federation" => Ok(EventFormat::Federation),
-                    _ => Err(E::invalid_value(&format!("unknown {} variant: {}",
-                                                       stringify!( EventFormat), value))),
-                }
-            }
-        }
-
-        // Deserialize the enum from a string.
-        deserializer.deserialize_str(Visitor)
-    }
-}
-
-/// FilterResponse
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FilterResponse {
-    /// Filters to be applied to room data.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub room: Option<RoomFilter>,
-    /// The presence updates to include.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub presence: Option<Filter>,
-    /// The user account data that isn't associated with rooms to include.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_data: Option<Filter>,
-    /// The format to use for events.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub event_format: Option<EventFormat>,
-    /// List of event fields to include.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(default)]
-    pub event_fields: Vec<String>,
-}
 
 /// The GET `/user/:user_id/filter/:filter_id` endpoint.
 pub struct GetFilter;
@@ -195,8 +26,8 @@ impl Handler for GetFilter {
             .expect("FilterIdParam should ensure a FilterIdParam").clone();
 
         let connection = DB::from_request(request)?;
-        let filter = DataFilter::find(&connection, user_id, filter_id)?;
-        let response: FilterResponse = from_str(&filter.content).map_err(ApiError::from)?;
+        let filter = Filter::find(&connection, user_id, filter_id)?;
+        let response: ContentFilter = from_str(&filter.content).map_err(ApiError::from)?;
         Ok(Response::with((Status::Ok, SerializableResponse(response))))
     }
 }
@@ -223,7 +54,7 @@ impl Handler for PostFilter {
             Err(ApiError::unauthorized("The given user_id does not correspond to the authenticated user".to_string()))?;
         }
 
-        let filter = match request.get::<bodyparser::Struct<FilterResponse>>() {
+        let filter = match request.get::<bodyparser::Struct<ContentFilter>>() {
             Ok(Some(account_password_request)) => account_password_request,
             Ok(None) | Err(_) => {
                 let error = ApiError::bad_json(None);
@@ -233,7 +64,7 @@ impl Handler for PostFilter {
 
         let connection = DB::from_request(request)?;
 
-        let id = DataFilter::create(&connection, user_id, filter. to_json().to_string())?;
+        let id = Filter::create(&connection, user_id, filter. to_json().to_string())?;
 
         let response = PostFilterResponse {
             filter_id: id.to_string(),

--- a/src/api/r0/join.rs
+++ b/src/api/r0/join.rs
@@ -167,8 +167,7 @@ mod tests {
     #[test]
     fn join_own_public_room() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let room_id = test.create_public_room(&access_token);
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
 
         let room_join_path = format!(
             "/_matrix/client/r0/rooms/{}/join?access_token={}",
@@ -185,10 +184,8 @@ mod tests {
     #[test]
     fn join_other_public_room() {
         let test = Test::new();
-        let carl_token = test.create_access_token_with_username("carl");
+        let (_, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
         let mark_token = test.create_access_token_with_username("mark");
-
-        let room_id = test.create_public_room(&carl_token);
 
         let room_join_path = format!(
             "/_matrix/client/r0/rooms/{}/join?access_token={}",
@@ -205,8 +202,7 @@ mod tests {
     #[test]
     fn join_own_private_room() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let room_id = test.create_private_room(&access_token);
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "private"}"#);
 
         let room_join_path = format!(
             "/_matrix/client/r0/rooms/{}/join?access_token={}",
@@ -244,10 +240,8 @@ mod tests {
     #[test]
     fn join_other_private_room_without_invite() {
         let test = Test::new();
-        let bob_token = test.create_access_token_with_username("bob");
+        let (_, room_id) = test.initial_fixtures("bob", r#"{"visibility": "private"}"#);
         let alice_token = test.create_access_token_with_username("alice");
-
-        let room_id = test.create_private_room(&bob_token);
 
         let room_join_path = format!(
             "/_matrix/client/r0/rooms/{}/join?access_token={}",
@@ -263,10 +257,8 @@ mod tests {
     #[test]
     fn invite_to_room() {
         let test = Test::new();
-        let bob_token = test.create_access_token_with_username("bob");
+        let (bob_token, room_id) = test.initial_fixtures("bob", r#"{"visibility": "private"}"#);
         let alice_token = test.create_access_token_with_username("alice");
-
-        let room_id = test.create_private_room(&bob_token);
 
         let response = test.invite(&bob_token, &room_id, "@alice:ruma.test");
 
@@ -300,9 +292,8 @@ mod tests {
     #[test]
     fn invite_without_user_id() {
         let test = Test::new();
-        let carl_token = test.create_access_token_with_username("carl");
+        let (carl_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "private"}"#);
 
-        let room_id = test.create_private_room(&carl_token);
         let invite_path = format!(
             "/_matrix/client/r0/rooms/{}/invite?access_token={}",
             room_id,
@@ -326,9 +317,7 @@ mod tests {
     #[test]
     fn invitee_does_not_exist() {
         let test = Test::new();
-        let carl_token = test.create_access_token_with_username("carl");
-
-        let room_id = test.create_private_room(&carl_token);
+        let (carl_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "private"}"#);
 
         // User 'mark' does not exist.
         let response = test.invite(&carl_token, &room_id, "@mark:ruma.test");
@@ -343,8 +332,7 @@ mod tests {
     #[test]
     fn invitee_is_invalid() {
         let test = Test::new();
-        let carl_token = test.create_access_token();
-        let room_id = test.create_private_room(&carl_token);
+        let (carl_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "private"}"#);
 
         let response = test.invite(&carl_token, &room_id, "mark.ruma.test");
 

--- a/src/api/r0/members.rs
+++ b/src/api/r0/members.rs
@@ -48,8 +48,7 @@ mod tests {
     #[test]
     fn room_members() {
         let test = Test::new();
-        let access_token = test.create_access_token();
-        let room_id = test.create_public_room(&access_token);
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
 
         let room_join_path = format!(
             "/_matrix/client/r0/rooms/{}/join?access_token={}",

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -16,6 +16,7 @@ pub use self::profile::{Profile, GetAvatarUrl, PutAvatarUrl, GetDisplayName, Put
 pub use self::registration::Register;
 pub use self::room_creation::CreateRoom;
 pub use self::tags::{DeleteTag, GetTags, PutTag};
+pub use self::sync::Sync;
 pub use self::versions::Versions;
 pub use self::filter::{GetFilter, PostFilter};
 
@@ -31,4 +32,5 @@ mod profile;
 mod registration;
 mod room_creation;
 mod tags;
+mod sync;
 mod versions;

--- a/src/api/r0/sync.rs
+++ b/src/api/r0/sync.rs
@@ -1,0 +1,373 @@
+//! Endpoints for syncing.
+use std::u64;
+use std::error::Error;
+use std::str::FromStr;
+
+use iron::{Chain, Handler, IronResult, Request, Response};
+use iron::status::Status;
+use ruma_events::presence::PresenceState;
+use serde_json::from_str;
+
+use db::DB;
+use error::ApiError;
+use middleware::{AccessTokenAuth, MiddlewareChain};
+use modifier::SerializableResponse;
+use query::{self, Batch, SyncOptions};
+use models::user::User;
+
+/// The `/sync` endpoint.
+pub struct Sync;
+
+middleware_chain!(Sync, [AccessTokenAuth]);
+
+impl Handler for Sync {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let user = request.extensions.get::<User>()
+            .expect("AccessTokenAuth should ensure a user").clone();
+
+        let connection = DB::from_request(request)?;
+
+        let url = request.url.clone().into_generic_url();
+        let query_pairs = url.query_pairs().into_owned();
+
+        let mut filter = None;
+        let mut since = None;
+        let mut full_state = false;
+        let mut set_presence = PresenceState::Offline;
+        let mut timeout = 0;
+        for tuple in query_pairs {
+            match (tuple.0.as_ref(), tuple.1.as_ref()) {
+                ("filter", value) => {
+                    let content = from_str(value)
+                        .map_err(|err| ApiError::invalid_param("filter", err.description()))?;
+                    filter = Some(content);
+                },
+                ("since", value) => {
+                    let batch = Batch::from_str(value)
+                        .map_err(|err| ApiError::invalid_param("since", &err))?;
+                    since = Some(batch);
+                }
+                ("full_state", "true") => {
+                    full_state = true;
+                }
+                ("full_state", "false") => {
+                    full_state = false;
+                }
+                ("full_state", _) => {
+                    Err(ApiError::invalid_param("set_presence", "No boolean!"))?;
+                }
+                ("set_presence", "online") => {
+                    set_presence = PresenceState::Online;
+                }
+                ("set_presence", "unavailable") => {
+                    set_presence = PresenceState::Unavailable;
+                }
+                ("set_presence", _) => {
+                    Err(ApiError::invalid_param("set_presence", "Invalid enum!"))?;
+                }
+                ("timeout", value) => {
+                    timeout = u64::from_str_radix(value, 10).map_err(|err| ApiError::invalid_param("timeout", err.description()))?;
+                }
+                _ => (),
+            }
+        }
+
+        let options = SyncOptions {
+            filter: filter,
+            since: since,
+            full_state: full_state,
+            set_presence: set_presence,
+            timeout: timeout,
+        };
+
+        let response = query::Sync::sync(&connection, user, options)?;
+
+        Ok(Response::with((Status::Ok, SerializableResponse(response))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use test::Test;
+    use iron::status::Status;
+    use ruma_events::presence::PresenceState;
+    use ruma_identifiers::EventId;
+    use serde_json::from_str;
+    use query::{SyncOptions};
+
+    /// [https://github.com/matrix-org/sytest/blob/0eba37fc567d65f0a005090548c8df4d0e43775f/tests/31sync/03joined.pl#L3]
+    #[test]
+    fn can_sync_a_joined_room() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let options = SyncOptions {
+            filter: None,
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let next_batch = Test::get_next_batch(&response);
+        let room = response.json().find_path(&["rooms", "join", room_id.as_ref()]).unwrap();
+        assert!(room.is_object());
+
+        let options = SyncOptions {
+            filter: None,
+            since: Some(next_batch),
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let room = response.json().find_path(&["rooms", "join", room_id.as_ref()]);
+        assert_eq!(room, None);
+    }
+
+    /// [https://github.com/matrix-org/sytest/blob/0eba37fc567d65f0a005090548c8df4d0e43775f/tests/31sync/03joined.pl#L43]
+    #[test]
+    fn full_state_sync_includes_joined_rooms() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":10}}}"#).unwrap()),
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let since = Test::get_next_batch(&response);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":10}}}"#).unwrap()),
+            since: Some(since),
+            full_state: true,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let room = response.json().find_path(&["rooms", "join", room_id.as_ref()]).unwrap();
+        Test::assert_json_keys(room, vec!["timeline", "state", "ephemeral"]);
+        Test::assert_json_keys(room.find("timeline").unwrap(), vec!["events", "limited", "prev_batch"]);
+        Test::assert_json_keys(room.find("state").unwrap(), vec!["events"]);
+        Test::assert_json_keys(room.find("ephemeral").unwrap(), vec!["events"]);
+    }
+
+    /// [https://github.com/matrix-org/sytest/blob/0eba37fc567d65f0a005090548c8df4d0e43775f/tests/31sync/03joined.pl#L81]
+    #[test]
+    fn newly_joined_room_is_included_in_an_incremental_sync() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":10}}}"#).unwrap()),
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let since = Test::get_next_batch(&response);
+        let room_id = test.create_room(&access_token);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":10}}}"#).unwrap()),
+            since: Some(since),
+            full_state: true,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let since = Test::get_next_batch(&response);
+        let room = response.json().find_path(&["rooms", "join", room_id.as_ref()]).unwrap();
+        Test::assert_json_keys(room, vec!["timeline", "state", "ephemeral"]);
+        Test::assert_json_keys(room.find("timeline").unwrap(), vec!["events", "limited", "prev_batch"]);
+        Test::assert_json_keys(room.find("state").unwrap(), vec!["events"]);
+        Test::assert_json_keys(room.find("ephemeral").unwrap(), vec!["events"]);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":10}}}"#).unwrap()),
+            since: Some(since),
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let room = response.json().find_path(&["rooms", "join", room_id.as_ref()]);
+        assert_eq!(room, None);
+    }
+
+    /// [https://github.com/matrix-org/sytest/blob/0eba37fc567d65f0a005090548c8df4d0e43775f/tests/31sync/04timeline.pl#L1]
+    #[test]
+    fn can_sync_a_room_with_a_single_message() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.send_message(&access_token, &room_id, "Hi Test 1");
+        let event_id_1 = response.json().find("event_id").unwrap().as_str().unwrap();
+
+        let response = test.send_message(&access_token, &room_id, "Hi Test 2");
+        let event_id_2 = response.json().find("event_id").unwrap().as_str().unwrap();
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":2}}}"#).unwrap()),
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let json = response.json();
+        let timeline = json.find_path(&["rooms", "join", room_id.as_ref(), "timeline"]).unwrap();
+        assert_eq!(timeline.find("limited").unwrap().as_bool().unwrap(), true);
+        let events = timeline.find("events").unwrap();
+        assert!(events.is_array());
+        let events = events.as_array().unwrap();
+        assert_eq!(events.len(), 2);
+        let mut events = events.into_iter();
+        let event = events.next().unwrap();
+        assert_eq!(EventId::try_from(event.find("event_id").unwrap().as_str().unwrap()).unwrap().opaque_id(), event_id_1);
+        let event = events.next().unwrap();
+        assert_eq!(EventId::try_from(event.find("event_id").unwrap().as_str().unwrap()).unwrap().opaque_id(), event_id_2);
+    }
+
+    /// [https://github.com/matrix-org/sytest/blob/0eba37fc567d65f0a005090548c8df4d0e43775f/tests/31sync/04timeline.pl#L223]
+    #[test]
+    fn syncing_a_new_room_with_a_large_timeline_limit_isnt_limited() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let options = SyncOptions {
+            filter: Some(from_str(r#"{"room":{"timeline":{"limit":100}}}"#).unwrap()),
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let json = response.json();
+        let timeline = json.find_path(&["rooms", "join", room_id.as_ref(), "timeline"]).unwrap();
+        assert_eq!(timeline.find("limited").unwrap().as_bool().unwrap(), false);
+    }
+
+    #[test]
+    fn initial_state() {
+        let test = Test::new();
+        let access_token = test.create_access_token();
+
+        let sync_path = format!(
+            "/_matrix/client/r0/sync?access_token={}",
+            access_token,
+        );
+
+        let response = test.get(&sync_path);
+        assert_eq!(response.status, Status::Ok);
+        let rooms = response.json().find("rooms").unwrap();
+        let join = rooms.find("join").unwrap();
+        assert!(join.is_object());
+        assert_eq!(join.as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn initial_state_find_joined_rooms() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        test.send_message(&access_token, &room_id, "Hi Test");
+
+        let options = SyncOptions {
+            filter: None,
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        assert_eq!(response.status, Status::Ok);
+        let json = response.json();
+        let events = json.find_path(&["rooms", "join", room_id.as_ref(), "timeline", "events"]).unwrap();
+        assert!(events.is_array());
+        assert_eq!(events.as_array().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn basic_since_state() {
+        let test = Test::new();
+        let (access_token, room_id) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let options = SyncOptions {
+            filter: None,
+            since: None,
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let next_batch = Test::get_next_batch(&response);
+
+        test.send_message(&access_token, &room_id, "test 1");
+
+        let options = SyncOptions {
+            filter: None,
+            since: Some(next_batch),
+            full_state: false,
+            set_presence: PresenceState::Offline,
+            timeout: 0
+        };
+        let response = test.sync(&access_token, options);
+        let json = response.json();
+        let events = json.find_path(&["rooms", "join", room_id.as_ref(), "timeline", "events"]).unwrap();
+        assert!(events.is_array());
+        assert_eq!(events.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn invalid_since() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.get(&format!("/_matrix/client/r0/sync?since={}&access_token={}", "10s_234", access_token));
+        assert_eq!(response.status, Status::BadRequest);
+    }
+
+    #[test]
+    fn invalid_timeout() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.get(&format!("/_matrix/client/r0/sync?timeout={}&access_token={}", "10s_234", access_token));
+        assert_eq!(response.status, Status::BadRequest);
+    }
+
+    #[test]
+    fn invalid_set_presence() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.get(&format!("/_matrix/client/r0/sync?set_presence={}&access_token={}", "10s_234", access_token));
+        assert_eq!(response.status, Status::BadRequest);
+    }
+
+    #[test]
+    fn invalid_filter() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.get(&format!("/_matrix/client/r0/sync?filter={}&access_token={}", "{10s_234", access_token));
+        assert_eq!(response.status, Status::BadRequest);
+    }
+
+    #[test]
+    fn invalid_full_state() {
+        let test = Test::new();
+        let (access_token, _) = test.initial_fixtures("carl", r#"{"visibility": "public"}"#);
+
+        let response = test.get(&format!("/_matrix/client/r0/sync?full_state={}&access_token={}", "{10s_234", access_token));
+        assert_eq!(response.status, Status::BadRequest);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::fmt::Error as FmtError;
 use std::io::Error as IoError;
 use std::string::FromUtf8Error;
 use std::sync::PoisonError;
+use std::time::SystemTimeError;
 
 use argon2rs::verifier::DecodeError;
 use base64::Base64Error;
@@ -238,6 +239,14 @@ impl From<Base64Error> for ApiError {
 
 impl From<DieselError> for ApiError {
     fn from(error: DieselError) -> ApiError {
+        debug!("Converting to ApiError from: {:?}", error);
+
+        ApiError::unknown(None)
+    }
+}
+
+impl From<SystemTimeError> for ApiError {
+    fn from(error: SystemTimeError) -> ApiError {
         debug!("Converting to ApiError from: {:?}", error);
 
         ApiError::unknown(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ pub mod models;
 pub mod modifier;
 pub mod schema;
 pub mod server;
+pub mod query;
 pub mod swagger;
 #[cfg(test)] pub mod test;
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -37,7 +37,7 @@ macro_rules! middleware_chain {
     };
 }
 
-/// MiddlewareChain
+/// `MiddlewareChain` ensures that endpoints have a chain function.
 pub trait MiddlewareChain {
     /// Create a `MiddlewareChain` with all necessary middleware.
     fn chain() -> Chain;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,337 @@
+//! Matrix sync.
+use std::cmp;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::i64;
+use std::iter::Iterator;
+use std::str::FromStr;
+
+use diesel::pg::PgConnection;
+use ruma_events::room::member::MemberEvent;
+use ruma_events::room::message::MessageEvent;
+use ruma_events::room::history_visibility::HistoryVisibilityEvent;
+use ruma_events::presence::PresenceState;
+use ruma_identifiers::RoomId;
+use serde_json::{Value, to_value};
+
+use error::ApiError;
+use models::event::Event;
+use models::filter::{ContentFilter, RoomEventFilter, RoomFilter};
+use models::room_membership::RoomMembership;
+use models::user::User;
+
+#[derive(Debug, Clone, Serialize)]
+struct UnreadNotificationCounts {
+    highlight_count: u64,
+    notification_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Timeline {
+    limited: bool,
+    prev_batch: String,
+    events: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Events<T> {
+    events: Vec<T>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LeftRoom {
+    timeline: Timeline,
+    state: Events<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct InvitedRoom {
+    invite_state: Events<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct JoinedRoom {
+    unread_notifications: UnreadNotificationCounts,
+    timeline: Timeline,
+    state: Events<Value>,
+    account_data: Events<Value>,
+    ephemeral: Events<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct Rooms {
+    join: HashMap<RoomId, JoinedRoom>,
+    leave: HashMap<RoomId, LeftRoom>,
+    invite: HashMap<RoomId, InvitedRoom>,
+}
+
+/// A Sync response.
+#[derive(Debug, Clone, Serialize)]
+pub struct Sync {
+    next_batch: String,
+    presence: Events<Value>,
+    rooms: Rooms,
+}
+
+/// A State Ordering.
+#[derive(Debug, Clone)]
+pub struct Batch {
+    /// The room ordering key.
+    pub room_key: i64,
+    /// The presence ordering key.
+    pub presence_key: i64,
+}
+
+impl Batch {
+    /// Create a new `Batch`.
+    pub fn new(room_key: i64, presence_key: i64) -> Batch {
+        Batch {
+            room_key: room_key,
+            presence_key: presence_key,
+        }
+    }
+}
+
+impl Display for Batch {
+    /// Make a String from a `Batch`.
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}_{}", self.room_key, self.presence_key)
+    }
+}
+
+impl FromStr for Batch {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Batch, String> {
+        let values: Vec<&str> = s.split('_').collect();
+
+        if values.len() != 2 {
+            return Err(String::from("Wrong number of tokens"));
+        }
+
+        let room_key = i64::from_str_radix(values[0], 10)
+            .map_err(|err| err.to_string())?;
+
+        let presence_key = i64::from_str_radix(values[1], 10)
+            .map_err(|err| err.to_string())?;
+
+        Ok(Batch::new(room_key, presence_key))
+    }
+}
+
+/// A Sync query options.
+#[derive(Debug)]
+pub struct SyncOptions {
+    /// The ID of a filter created using the filter API or a filter JSON object encoded as a string.
+    pub filter: Option<ContentFilter>,
+    /// A point in time to continue a sync from.
+    pub since: Option<Batch>,
+    /// Controls whether to include the full state for all rooms the user is a member of.
+    pub full_state: bool,
+    /// Controls whether the client is automatically marked as online by polling this API.
+    pub set_presence: PresenceState,
+    /// The maximum time to poll in milliseconds before returning this request.
+    pub timeout: u64,
+}
+
+/// Sync update context
+#[derive(Debug)]
+pub enum Context<'a> {
+    /// full state
+    FullState(&'a Batch),
+    /// incremental
+    Incremental(&'a Batch),
+    /// initial
+    Initial,
+}
+
+impl Sync {
+    /// Query sync.
+    pub fn sync(
+        connection: &PgConnection,
+        user: User,
+        options: SyncOptions,
+    ) -> Result<Sync, ApiError> {
+        let mut context = Context::Initial;
+        if let Some(ref batch) = options.since {
+            context = if options.full_state {
+                Context::FullState(batch)
+            } else {
+                Context::Incremental(batch)
+            }
+        }
+
+        let filter_room = match options.filter {
+            Some(filter) => filter.room,
+            None => None
+        };
+
+        let (room_key, rooms) = Sync::sync_rooms(connection, user, filter_room, &context)?;
+        let batch = Batch::new(room_key, 0);
+        let state = Sync {
+            next_batch: batch.to_string(),
+            presence: Events {
+                events: Vec::new(),
+            },
+            rooms: rooms,
+        };
+        Ok(state)
+    }
+
+    /// Converting events in the correct format for timeline.
+    fn convert_events_to_timeline(events: Vec<Event>, timeline_filter: &Option<RoomEventFilter>) -> Result<(i64, Timeline), ApiError> {
+        let mut room_ordering = 0;
+        let mut timeline_events = Vec::new();
+        let mut limited = false;
+
+        let length = events.len();
+
+        let count = match *timeline_filter {
+            None => 0,
+            Some(ref filter) => {
+                match filter.limit {
+                    0 => 0,
+                    x => {
+                        if length > x {
+                            limited = true;
+                            length - x
+                        } else {
+                            0
+                        }
+                    },
+                }
+            }
+        };
+
+        for event in events.into_iter().skip(count) {
+            room_ordering = cmp::max(room_ordering, event.ordering);
+            let value = match event.event_type.as_ref() {
+                "m.room.member" => {
+                    let member_event: MemberEvent = event.try_into()?;
+                    to_value(&member_event)
+                },
+                "m.room.message" => {
+                    let message_event: MessageEvent = event.try_into()?;
+                    to_value(&message_event)
+                },
+                "m.room.history_visibility" => {
+                    let message_event: HistoryVisibilityEvent = event.try_into()?;
+                    to_value(&message_event)
+                },
+                _ => {
+                    println!("unhandled {:?}", event.event_type);
+                    Value::Null
+                },
+            };
+            timeline_events.push(value);
+        }
+
+        Ok((room_ordering, Timeline {
+            events: timeline_events,
+            limited: limited,
+            prev_batch: String::from(""),
+        }))
+    }
+
+    /// Return rooms for sync from database and options.
+    fn sync_rooms(
+        connection: &PgConnection,
+        user: User,
+        room_filter: Option<RoomFilter>,
+        context: &Context,
+    ) -> Result<(i64, Rooms), ApiError> {
+        let mut room_ordering = 0;
+        let mut join = HashMap::new();
+        let mut invite = HashMap::new();
+        let mut leave = HashMap::new();
+
+        let room_memberships = RoomMembership::find_by_user_id_order_by_room_id(connection, &user.id)?;
+
+        let since = match *context {
+            Context::Incremental(batch) => batch.room_key,
+            Context::FullState(_) | Context::Initial => -1,
+        };
+        let timeline_filter = match room_filter {
+            Some(filter) => filter.timeline,
+            None => None,
+        };
+
+        for room_membership in room_memberships {
+            let events: Vec<Event> = Event::find_room_events(connection, &room_membership.room_id, since)?;
+            if events.is_empty() {
+                continue;
+            }
+            match room_membership.membership.as_str() {
+                "join" => {
+                    let (i, timeline) = Sync::convert_events_to_timeline(events, &timeline_filter)?;
+                    room_ordering = cmp::max(i, room_ordering);
+                    join.insert(room_membership.room_id, JoinedRoom {
+                        unread_notifications: UnreadNotificationCounts {
+                            highlight_count: 0,
+                            notification_count: 0,
+                        },
+                        timeline: timeline,
+                        state: Events {
+                            events: Vec::new(),
+                        },
+                        account_data: Events {
+                            events: Vec::new(),
+                        },
+                        ephemeral: Events {
+                            events: Vec::new(),
+                        },
+                    });
+                },
+                "invite" => {
+                    invite.insert(room_membership.room_id, InvitedRoom {
+                        invite_state: Events {
+                            events: Vec::new(),
+                        },
+                    });
+                },
+                "leave" => {
+                    let (i, timeline) = Sync::convert_events_to_timeline(events, &timeline_filter)?;
+                    room_ordering = cmp::max(i, room_ordering);
+                    leave.insert(room_membership.room_id, LeftRoom {
+                        timeline: timeline,
+                        state: Events {
+                            events: Vec::new(),
+                        },
+                    });
+                },
+                _ => (),
+            }
+        }
+
+        Ok((room_ordering, Rooms {
+            join: join,
+            leave: leave,
+            invite: invite,
+        }))
+    }
+}
+
+#[test]
+fn batch_to_str() {
+    let batch = Batch::new(10, 10);
+    assert_eq!(batch.to_string(), String::from("10_10"));
+}
+
+#[test]
+fn batch_parse() {
+    let batch = Batch::from_str("10_12").unwrap();
+    assert_eq!(batch.room_key, 10);
+    assert_eq!(batch.presence_key, 12);
+}
+
+#[test]
+fn batch_parse_non_number() {
+    let batch = Batch::from_str("10_12a");
+    assert!(batch.is_err());
+}
+
+#[test]
+fn batch_parse_too_many() {
+    let batch = Batch::from_str("10_12_12");
+    assert!(batch.is_err());
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,6 +36,7 @@ use api::r0::{
     Register,
     SendMessageEvent,
     StateMessageEvent,
+    Sync,
     Versions,
 };
 use config::Config;
@@ -119,6 +120,7 @@ impl<'a> Server<'a> {
         r0_router.delete("/user/:user_id/rooms/:room_id/tags/:tag", DeleteTag::chain(), "delete_tag");
         r0_router.get("/user/:user_id/filter/:filter_id", GetFilter::chain(), "get_filter");
         r0_router.post("/user/:user_id/filter", PostFilter::chain(), "post_filter");
+        r0_router.get("/sync", Sync::chain(), "sync");
 
         let mut r0 = Chain::new(r0_router);
 


### PR DESCRIPTION
## Spec

https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync
## Parameters
- [x] since
- [x] full_state
- [x] filter
- [ ] timeout
- [ ] set_presence
## State
- [x] next_batch
- [ ] presence
  - [ ] events
- [ ] rooms
  - [x] join
    - [ ] unread_notifications
    - [ ] timeline
      - [x] limited
      - [ ] prev_batch
      - [x] events (basic)
    - [ ] state
      - [ ] events
    - [ ] account_data
      - [ ] events
    - [ ] ephemeral
      - [ ] events
  - [x] leave
    - [ ] timeline
      - [ ] limited
      - [ ] prev_batch
      - [ ] events
    - [ ] state
      - [ ] events
  - [x] invite
    - [ ] invite_state
      - [ ] events
## Details
- Support partial `timeline.events`, `timeline.limited`
- No support for `timeline.prev_batch`
- Support following in `timeline.events` (`m.room.member`, `m.room.message`, `m.room.history_visibility`)
- Support `timeline` limiting by `filter`
- Support partial `since`, `full_state`
- Remove empty rooms `rooms.join`, `rooms.leave`, `rooms.invite`
- Parse all parameters `since`, `filter`, `full_state`, `set_presence`, `timeout`
- No support for parameter: `set_presence`, `timeout`
- Basic invalidation for parameters
- Basic macro for TryInto e.g. impl MessageEvent for Event