### PR TITLE
Trait-based events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,38 +3,38 @@ name = "ruma"
 version = "0.1.0"
 dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_codegen 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron-test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "macaroons 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "persistent 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2-diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "router 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2-diesel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruma-events 0.1.0 (git+https://github.com/ruma/ruma-events)",
- "ruma-identifiers 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruma-identifiers 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,7 +42,12 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.8.0"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "antidote"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -55,13 +60,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "aster"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "base64"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -83,10 +83,10 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "persistent 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "persistent 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -99,20 +99,21 @@ name = "chrono"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "2.10.0"
+version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -122,7 +123,7 @@ name = "conduit-mime-types"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -136,35 +137,38 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "pq-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pq-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_codegen"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel_codegen_syntex 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_codegen_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "diesel_codegen_syntex"
-version = "0.7.1"
+name = "diesel_codegen_shared"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -174,11 +178,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -192,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.32"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -214,29 +218,29 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.9.10"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -244,7 +248,7 @@ name = "idna"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -256,14 +260,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -271,10 +275,10 @@ name = "iron-test"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -304,12 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -325,8 +329,17 @@ name = "libsodium-sys"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -340,13 +353,13 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "matches"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,7 +367,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -381,12 +394,12 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -394,7 +407,7 @@ name = "num-integer"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -403,12 +416,12 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -416,7 +429,15 @@ name = "num_cpus"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -425,20 +446,20 @@ version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.7.15"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -449,9 +470,9 @@ name = "openssl-sys-extras"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -464,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "persistent"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -494,73 +515,63 @@ dependencies = [
 
 [[package]]
 name = "pq-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
-name = "quasi"
-version = "0.16.0"
+name = "quote"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quasi_codegen"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aster 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quasi_macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quasi_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "r2d2"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "r2d2-diesel"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.73"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.3.4"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -570,40 +581,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "router"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ruma-events"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma-events#a23203317e330b18f0e261db520e8fc7b84bff53"
+source = "git+https://github.com/ruma/ruma-events#c7228fc3b333b5c632cf1099465ca0078668cf9f"
 dependencies = [
- "ruma-identifiers 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruma-identifiers 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ruma-identifiers"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -636,51 +648,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.8.1"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_codegen"
-version = "0.8.1"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aster 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quasi_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_codegen_internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen_internals 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_codegen_internals"
-version = "0.5.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_codegen 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_json"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "serde_macros"
-version = "0.8.1"
+name = "serde_test"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_codegen 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -688,7 +712,7 @@ name = "sodiumoxide"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -704,23 +728,43 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "term_size"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -729,12 +773,12 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -746,16 +790,16 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -794,7 +838,7 @@ name = "unicode-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -803,8 +847,18 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-segmentation"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -817,11 +871,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.2.0"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -843,7 +897,7 @@ name = "uuid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -863,35 +917,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yaml-rust"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [metadata]
-"checksum aho-corasick 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b3fb52b09c1710b961acb35390d514be82e4ac96a9969a8e38565a29b878dc9"
-"checksum ansi_term 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c877397e09fec7a240af5fa74ad0124054b8066149d6544cd1ace93f8de3be68"
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+"checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
-"checksum aster 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2e21e476ef6522e1762461ddbd1eba4d049c9a86619ccd03226b09f3d0741e"
-"checksum base64 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ce110e5c96df1817009271c910626fa4b79c2f178d70f9857d768c3886ba6a0"
+"checksum base64 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2015e3793554aa5b6007e3a72959e84c1070039e74f13dde08fa64afe1ddd892"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum blake2-rfc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0c6a476f32fef3402f1161f89d0d39822809627754a126f8441ff2a9d45e2d59"
 "checksum bodyparser 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07b171b407e583dc8f01011a713f20575a81ac60acecf3b8153012709aeb1fd6"
 "checksum byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "29b2aa490a8f546381308d68fc79e6bd753cd3ad839f7a7172897f1feedfa175"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
-"checksum clap 2.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6adb6a046b8155874daf331e6cb6f4a3edf3ea3cbc625809eb4077a384124761"
+"checksum clap 2.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef87e92396a3d29bf7e611c8a595be35ae90d9cb844a3571425900eaca4f51c8"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum constant_time_eq 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07dcb7959f0f6f1cf662f9a7ff389bcb919924d99ac41cf31f10d611d8721323"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
-"checksum diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "57577c0fd5ad12d03ce0f4496299e41af842e8795caf5f260a20505d3554411a"
-"checksum diesel_codegen 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80391caac611d7ea50a4be312088e573d3a505b14d450cf766c2eb25120d873b"
-"checksum diesel_codegen_syntex 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bb8bc90ef990d0bbfbb62bd5722559f95f0f15020532d6096f62b1d7b17f7f0"
+"checksum diesel 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db28fcebf975cf122aa96563ad67c1f1db43eba60894f3138691efcc7eb97163"
+"checksum diesel_codegen 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f426e9447ca26ff2b6873d50e90377667a4aedb0ced6132bb5fa3bda2eda164d"
+"checksum diesel_codegen_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d4c594e4fce9b1dc34bf82220493204fffa323354f44f3c391824423986caf"
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
-"checksum env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82dcb9ceed3868a03b335657b85a159736c961900f7e7747d3b0b97b9ccb5ccb"
+"checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e606f14042bb87cc02ef6a14db6c90ab92ed6f62d87e69377bc759fd7987cc"
-"checksum gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "dcb000abd6df9df4c637f75190297ebe56c1d7e66b56bbf3b4aa7aece15f61a2"
+"checksum gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "553f11439bdefe755bf366b264820f1da70f3aaf3924e594b886beb9c831bcf5"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d2da7d3a34cf6406d9d700111b8eafafe9a251de41ae71d8052748259343b58"
-"checksum httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46534074dbb80b070d60a5cb8ecadd8963a00a438ae1a95268850a7ef73b67ae"
-"checksum hyper 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "eb27e8a3e8f17ac43ffa41bbda9cf5ad3f9f13ef66fa4873409d4902310275f7"
+"checksum httparse 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8abece705b1d32c478f49447b3a575cd07f6e362ff12518f2ee2c9b9ced64e"
+"checksum hyper 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "86ea0c0ff7e6ef09eff72234800ddb48b6263277936e7ecd6ecd3250345d705f"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum iron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fb1b2d809f84bf347e472d5758762b5c804e0c622970235f156d82673e4d334"
 "checksum iron-test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33639388568efb87186cb30031b9e2445eb2dd95aa12d137f88eae61934439ab"
@@ -899,64 +956,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
-"checksum lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49247ec2a285bb3dcb23cbd9c35193c025e7251bfce77c1d5da97e6362dffe7f"
-"checksum libc 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "23e3757828fa702a20072c37ff47938e9dd331b92fac6e223d26d4b7a55f7ee2"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "044d1360593a78f5c8e5e710beccdc24ab71d1f01bc19a29bcacdba22e8475d8"
 "checksum libressl-pnacl-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cbc058951ab6a3ef35ca16462d7642c4867e6403520811f28537a4e2f2db3e71"
 "checksum libsodium-sys 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "44e9986c330611ccd26ea74e502c70e5ebab2874c4c23f2f5f3c5a6ed3fbfbc6"
+"checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum macaroons 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e53bad6fa1650178bdcb1b71ef9818aa4844172a2cda73e89c3e813538f4cb7"
-"checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
+"checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 "checksum mount 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c518ef1edf5da3aa1cdd5160c08d1781995ccb74b5669c2315ce29fe6cf6c1f2"
-"checksum num 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "d2ee34a0338c16ae67afb55824aaf8852700eb0f77ccd977807ccb7606b295f6"
+"checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
-"checksum num-traits 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "95e58eac34596aac30ab134c8a8da9aa2dc99caa4b4b4838e6fc6e298016278f"
+"checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum num_cpus 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "cee7e88156f3f9e19bdd598f8d6c9db7bf4078f99f8381f43a55b09648d1a6e3"
+"checksum num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8890e6084723d57d0df8d2720b0d60c6ee67d6c93e7169630e4371e88765dcad"
 "checksum openssl 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c4117b6244aac42ed0150a6019b4d953d28247c5dd6ae6f46ae469b5f2318733"
-"checksum openssl-sys 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "91a3921c122ca08e611f10a024a1c9186d0d7bd048afb83ab7bc9ec2576801fd"
+"checksum openssl-sys 0.7.17 (registry+https://github.com/rust-lang/crates.io-index)" = "89c47ee94c352eea9ddaf8e364be7f978a3bb6d66d73176572484238dd5a5c3f"
 "checksum openssl-sys-extras 0.7.14 (registry+https://github.com/rust-lang/crates.io-index)" = "11c5e1dba7d3d03d80f045bf0d60111dc69213b67651e7c889527a3badabb9fa"
 "checksum openssl-verify 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ed86cce894f6b0ed4572e21eb34026f1dc8869cb9ee3869029131bc8c3feb2d"
-"checksum persistent 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebaf2f9f9881f73e82ba23164a40d3500112d8e7ad056cdde451874f1814a4d9"
+"checksum persistent 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c0aea7e6e026f9090c56aa7cda9d4ad6f182c717f0640cb03beace1f75a43d2"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum plugin 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a6a0dc3910bc8db877ffed8e457763b317cf880df4ae19109b9f77d277cf6e0"
 "checksum pnacl-build-helper 1.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "61c9231d31aea845007443d62fcbb58bb6949ab9c18081ee1e09920e0cf1118b"
-"checksum pq-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d50c9cdaa6f0e09c7ddc29cfcf573ba18e00bb29bbfd7c2d49e4196d9851436b"
-"checksum quasi 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "314e56e9e59af71a5b1f09fab15e8e66ab2ccb786688f8d2e04d98b8d7cbc161"
-"checksum quasi_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a3856abd5ec12f873eeac0837cce65ac33814ed4acba287a9e806620763d4b7"
-"checksum quasi_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b530b7ff57b6a38e4d53909c64657f40e0eef6a8fea1f0943d76160c277c9c5"
-"checksum r2d2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63c7dd6655b3165145c5c140e8548ba2176a263682c07aaead2fe79eedd97bc"
-"checksum r2d2-diesel 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a280682e7f406dc989f4b710b2a8d864fbaba9f94342a302272f413f554e39b"
-"checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
-"checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"
-"checksum regex-syntax 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "31040aad7470ad9d8c46302dcffba337bb4289ca5da2e3cd6e37b64109a85199"
+"checksum pq-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bef99a69a5220cade3a7bd056ea33abde833b14d872bca84dddc98663c4a911c"
+"checksum quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5cf478fe1006dbcc72567121d23dbdae5f1632386068c5c86ff4f645628504"
+"checksum quote 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6732e32663c9c271bfc7c1823486b471f18c47a2dbf87c066897b7b51afc83be"
+"checksum r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecfed1b03be2e66624ec87cef173dad54253f25405bd3c918b321e4dda3ad32"
+"checksum r2d2-diesel 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acdada4f8c81b10e84cf6e273de0363d8b28b7929265587622a74643566ad7cc"
+"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4f0a750d020adb1978f5964ea7bca830585899b09da7cbb3f04961fc2400122d"
-"checksum router 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff665ba113dc57ef54604ded19375c5ddd23ec44b550a3667c595205b5f98b42"
+"checksum router 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b94397bfa5b772b4375be4da12560a7c1c1e74b2e35c46ed312958aad56df726"
 "checksum ruma-events 0.1.0 (git+https://github.com/ruma/ruma-events)" = "<none>"
-"checksum ruma-identifiers 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0bbb73152b0a95aa7758e8e98ab51808cd59be64f9a5409a59e9b2f091547ee"
-"checksum rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "6159e4e6e559c81bd706afe9c8fd68f547d3e851ce12e76b1de7914bab61691b"
+"checksum ruma-identifiers 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb5b77c19bd1dfc151fe691fd2c6d09d5daf38a64fb6b4cb23c3fa7f51cf3ff"
+"checksum rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)" = "bff9fc1c79f2dec76b253273d07682e94a978bd8f132ded071188122b2af9818"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum scoped_threadpool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef399c8893e8cb7aa9696e895427fab3a6bf265977bb96e126f24ddd2cda85a"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum sequence_trie 0.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d5b4eb0f7d1ff9b9666d8b8ff543f3705dd464025269a5b0e1988ffa60ca1be8"
 "checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
-"checksum serde 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7720ad510b91c19de6a1728077821d9407c625018250c8a24a66716022a8a172"
-"checksum serde_codegen 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a2d62bdada37c7b060d63ecc47f526b0f31a01d3ae4c4cbdf175879474179d8a"
-"checksum serde_codegen_internals 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44e59907dba9744430fb83ab90e71a0545bf5ceb849650a1e1134009a05803b7"
-"checksum serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e10f8a9d94b06cf5d3bef66475f04c8ff90950f1be7004c357ff9472ccbaebc"
-"checksum serde_macros 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5b7e08d5c1ba580b788286ebbb193b7331705d5b016076a249cd11f637f1c066"
-"checksum serde_yaml 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "159ed553b5c249a0cec774f9ce2ea531cd8ce15c43bbfdd98ef76cf7f3ecf58a"
+"checksum serde 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "58a19c0871c298847e6b68318484685cd51fa5478c0c905095647540031356e5"
+"checksum serde_codegen 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ce29a6ae259579707650ec292199b5fed2c0b8e2a4bdc994452d24d1bcf2242a"
+"checksum serde_codegen_internals 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59933a62554548c690d2673c5164f0c4a46be7c5731edfd94b0ecb1048940732"
+"checksum serde_derive 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b541549c4207d3602c9abcc3e31252e91751674264eb85c103bb20197054b4"
+"checksum serde_json 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1cb6b19e74d9f65b9d03343730b643d729a446b29376785cd65efdff4675e2fc"
+"checksum serde_test 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5da701f7e75804fc85ec07d39a9e0d5b22df4675a53582799bf65abef51cb308"
+"checksum serde_yaml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "545e06a77016c26c2014f08d485d8845f63b6c4158acc5a6a9fff505bba30bf6"
 "checksum sodiumoxide 0.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8d9da099120def269669aa349e0c3e97de4ab2c5cb9a54a765041651dd0055eb"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
-"checksum strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d5f575d5ced6634a5c4cb842163dab907dc7e9148b28dc482d81b8855cbe985"
+"checksum strsim 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "67f84c44fbb2f91db7fef94554e6b2ac05909c9c0b0bc23bb98d3a1aebfe7f7c"
+"checksum syn 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94e7d81ecd16d39f16193af05b8d5a0111b9d8d2f3f78f31760f327a247da777"
+"checksum syn 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6ae6fb0dcc9bd85f89a1a4adc0df2fd90c90c98849d61433983dd7a9df6363f7"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum term_size 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a7c9a4de31e5622ec38533988a9e965aab09b26ee8bd7b8b0f56d488c3784d"
+"checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55dd963dbaeadc08aa7266bf7f91c3154a7805e32bb94b820b769d2ef3b4744d"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
-"checksum toml 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a442dfc13508e603c3f763274361db7f79d7469a0e95c411cde53662ab30fc72"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
 "checksum traitobject 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dc23794ff47c95882da6f9d15de9a6be14987760a28cc0aafb40b7675ef09d8"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
@@ -964,13 +1025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a5906ca2b98c799f4b1ab4557b76367ebd6ae5ef14930ec841c74aed5f3764"
 "checksum unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1f7ceb96afdfeedee42bade65a0d585a6a0106f681b6749c8ff4daa8df30b3f"
 "checksum unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26643a2f83bac55f1976fb716c10234485f9202dcd65cfbdf9da49867b271172"
+"checksum unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b905d0fc2a1f0befd86b0e72e31d1787944efef9d38b9358a9e92a69757f7e3b"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
+"checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
 "checksum unsafe-any 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b351086021ebc264aea3ab4f94d61d889d98e5e9ec2d985d993f50133537fd3a"
-"checksum url 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afe9ec54bc4db14bc8744b7fed060d785ac756791450959b2248443319d5b119"
+"checksum url 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "48ccf7bd87a81b769cf84ad556e034541fb90e1cd6d4bc375c822ed9500cd9d7"
 "checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "885acc3b17fdef6230d1f7765dff1106dfd5e75a93c2f26459fbf600ed6dcc14"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum yaml-rust 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ebfe12f475ad59be6178ebf004d51e682022496535994f8d23fd7ed31084598c"
+"checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,41 +12,41 @@ version = "0.1.0"
 
 [dependencies]
 argon2rs = "0.2.5"
-base64 = "0.2.0"
+base64 = "0.2.1"
 bodyparser = "0.4.1"
 chrono = "0.2.25"
-clap = "2.10.0"
-diesel = "0.7.1"
-env_logger = "0.3.4"
+clap = "2.19.0"
+diesel = "0.8.2"
+env_logger = "0.3.5"
 iron = "0.4.0"
 log = "0.3.6"
 macaroons = "0.3.1"
 mount = "0.2.1"
-persistent = "0.2.0"
+persistent = "0.2.1"
 plugin = "0.2.6"
-r2d2 = "0.7.0"
-r2d2-diesel = "0.7.1"
-rand = "0.3.14"
-router = "0.2.0"
-rustc-serialize = "0.3.19"
-serde = "0.8.1"
-serde_json = "0.8.1"
-serde_macros = "0.8.1"
-serde_yaml = "0.4.0"
-toml = "0.2.0"
+r2d2 = "0.7.1"
+r2d2-diesel = "0.8.0"
+rand = "0.3.15"
+router = "0.4.0"
+rustc-serialize = "0.3.21"
+serde = "0.8.19"
+serde_derive = "0.8.19"
+serde_json = "0.8.3"
+serde_yaml = "0.5.0"
+toml = "0.2.1"
 unicase = "1.4.0"
 
 [dependencies.diesel_codegen]
 default-features = false
 features = ["postgres"]
-version = "0.7.1"
+version = "0.8.2"
 
 [dependencies.ruma-events]
 git = "https://github.com/ruma/ruma-events"
 
 [dependencies.ruma-identifiers]
 features = ["diesel"]
-version = "0.4.0"
+version = "0.4.3"
 
 [dev-dependencies]
 iron-test = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ You can also build and run Ruma in one step with `script/cargo run`.
 
 Ruma currently requires the nightly version of Rust because it uses the following unstable features, listed below with links to the GitHub issues tracking stabilization:
 
-* `custom_attribute`, `custom_derive`, `plugin`: These will all be replaced and stabilized soon by [Macros 1.1](https://github.com/rust-lang/rust/issues/35900).
-* [`question_mark`](https://github.com/rust-lang/rust/issues/31436)
-* [`specialization`](https://github.com/rust-lang/rust/issues/31844)
+* [`proc_macro`](https://github.com/rust-lang/rust/issues/35900).
 * [`try_from`](https://github.com/rust-lang/rust/issues/33417)
 
 When all of these features are stabilized, Ruma will target stable Rust.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: "2"
 services:
   rust:
     image: "rumaio/ruma-dev@sha256:4c1fed70a424f50ee25d714a7dfb824bea60d085300316b6644c1181c2869f84"
+    env:
+      # Workaround for https://github.com/rust-lang/cargo/issues/3340
+      # Can be removed if a fixed Cargo ever gets released. >:(
+      SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"
     links:
       - "postgres"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rust:
-    image: "rumaio/ruma-dev@sha256:7ba48e125971ef476b4750df45bd5bf9b3f4986b0f0c402edc2ddeb9e0be3ebb"
+    image: "rumaio/ruma-dev@sha256:4c1fed70a424f50ee25d714a7dfb824bea60d085300316b6644c1181c2869f84"
     links:
       - "postgres"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   rust:
-    image: "rumaio/ruma-dev@sha256:eb361c3196748a5c01248733de73bbf255c810a6c97ec64342b1d049639f08bb"
+    image: "rumaio/ruma-dev@sha256:7ba48e125971ef476b4750df45bd5bf9b3f4986b0f0c402edc2ddeb9e0be3ebb"
     links:
       - "postgres"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
   rust:
     image: "rumaio/ruma-dev@sha256:4c1fed70a424f50ee25d714a7dfb824bea60d085300316b6644c1181c2869f84"
-    env:
+    environment:
       # Workaround for https://github.com/rust-lang/cargo/issues/3340
       # Can be removed if a fixed Cargo ever gets released. >:(
       SSL_CERT_FILE: "/etc/ssl/certs/ca-certificates.crt"

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -15,8 +15,8 @@ use error::ApiError;
 use schema::access_tokens;
 
 /// A User access token.
-#[derive(Debug, Identifiable, Queryable)]
-#[changeset_for(access_tokens)]
+#[derive(AsChangeset, Debug, Identifiable, Queryable)]
+#[table_name = "access_tokens"]
 pub struct AccessToken {
     /// The access token's ID.
     pub id: i64,
@@ -33,8 +33,8 @@ pub struct AccessToken {
 }
 
 /// A new access token, not yet saved.
-#[derive(Debug)]
-#[insertable_into(access_tokens)]
+#[derive(Debug, Insertable)]
+#[table_name = "access_tokens"]
 pub struct NewAccessToken {
     /// The ID of the user who owns the access token.
     pub user_id: UserId,

--- a/src/account_data.rs
+++ b/src/account_data.rs
@@ -18,9 +18,8 @@ use error::ApiError;
 use schema::{account_data, room_account_data};
 
 /// Holds personal information/configuration for a user.
-#[derive(Debug, Clone, Identifiable, Queryable)]
-#[changeset_for(account_data)]
-#[table_name="account_data"]
+#[derive(AsChangeset, Debug, Clone, Identifiable, Queryable)]
+#[table_name = "account_data"]
 pub struct AccountData {
     /// Entry ID
     pub id: i64,
@@ -33,8 +32,8 @@ pub struct AccountData {
 }
 
 /// New account data, not yet saved.
-#[derive(Debug)]
-#[insertable_into(account_data)]
+#[derive(Debug, Insertable)]
+#[table_name = "account_data"]
 pub struct NewAccountData {
     /// The ID of the user who owns the data.
     pub user_id: UserId,
@@ -117,9 +116,8 @@ impl Key for AccountData {
 }
 
 /// Holds user's information/configuration per room.
-#[derive(Clone, Debug, Identifiable, Queryable)]
-#[changeset_for(room_account_data)]
-#[table_name="room_account_data"]
+#[derive(AsChangeset, Clone, Debug, Identifiable, Queryable)]
+#[table_name = "room_account_data"]
 pub struct RoomAccountData {
     /// Entry ID
     pub id: i64,
@@ -134,8 +132,8 @@ pub struct RoomAccountData {
 }
 
 /// New room account data, not yet saved.
-#[derive(Debug)]
-#[insertable_into(room_account_data)]
+#[derive(Debug, Insertable)]
+#[table_name = "room_account_data"]
 pub struct NewRoomAccountData {
     /// The ID of the user who owns the data.
     pub user_id: UserId,

--- a/src/api/r0/event_creation.rs
+++ b/src/api/r0/event_creation.rs
@@ -54,7 +54,6 @@ macro_rules! room_event {
         $ty {
             content: extract_event_content($event_content, &$event_type)?,
             event_id: $event_id.clone(),
-            extra_content: (),
             event_type: $event_type.clone(),
             room_id: $room_id.clone(),
             unsigned: None,
@@ -76,7 +75,6 @@ macro_rules! state_event {
         $ty {
             content: extract_event_content($event_content, &$event_type)?,
             event_id: $event_id.clone(),
-            extra_content: (),
             event_type: $event_type.clone(),
             prev_content: None,
             room_id: $room_id.clone(),
@@ -140,7 +138,6 @@ impl Handler for SendMessageEvent {
                 CustomRoomEvent {
                     content: event_content,
                     event_id: event_id.clone(),
-                    extra_content: (),
                     event_type: EventType::Custom(custom_event_type.clone()),
                     room_id: room_id.clone(),
                     unsigned: None,
@@ -343,7 +340,6 @@ impl Handler for StateMessageEvent {
                 CustomStateEvent {
                     content: event_content,
                     event_id: event_id.clone(),
-                    extra_content: (),
                     event_type: EventType::Custom(custom_event_type.clone()),
                     prev_content: None,
                     room_id: room_id.clone(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,6 +18,7 @@ use ruma_events::call::answer::AnswerEvent;
 use ruma_events::call::candidates::CandidatesEvent;
 use ruma_events::call::hangup::HangupEvent;
 use ruma_events::call::invite::InviteEvent;
+use ruma_events::room::aliases::AliasesEvent;
 use ruma_events::room::avatar::AvatarEvent;
 use ruma_events::room::canonical_alias::CanonicalAliasEvent;
 use ruma_events::room::create::CreateEvent;
@@ -148,6 +149,7 @@ impl_try_from_room_event_for_new_event!(InviteEvent);
 impl_try_from_room_event_for_new_event!(MessageEvent);
 impl_try_from_room_event_for_new_event!(CustomRoomEvent);
 
+impl_try_from_state_event_for_new_event!(AliasesEvent);
 impl_try_from_state_event_for_new_event!(AvatarEvent);
 impl_try_from_state_event_for_new_event!(CanonicalAliasEvent);
 impl_try_from_state_event_for_new_event!(CreateEvent);

--- a/src/event.rs
+++ b/src/event.rs
@@ -197,9 +197,7 @@ impl TryInto<MemberEvent> for Event {
 
                     from_value(field.clone()).map_err(ApiError::from)?
                 },
-                None => return Err(
-                    ApiError::unknown(Some("Data for member event was missing invite_room_state"))
-                ),
+                None => None,
             },
             prev_content: None,
             state_key: "".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 //! Ruma is a Matrix homeserver client API.
 
-#![feature(custom_attribute, custom_derive, plugin, question_mark, specialization, try_from)]
-#![plugin(diesel_codegen, serde_macros)]
+#![feature(proc_macro, question_mark, specialization, try_from)]
 #![deny(missing_docs)]
 
 extern crate argon2rs;
@@ -11,6 +10,7 @@ extern crate chrono;
 extern crate clap;
 extern crate env_logger;
 #[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 #[macro_use] extern crate iron;
 #[cfg(test)] extern crate iron_test;
 #[macro_use] extern crate log;
@@ -26,6 +26,7 @@ extern crate ruma_events;
 extern crate ruma_identifiers;
 extern crate rustc_serialize;
 extern crate serde;
+#[macro_use] extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_yaml;
 extern crate toml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! Ruma is a Matrix homeserver client API.
 
-#![feature(proc_macro, question_mark, specialization, try_from)]
+#![feature(proc_macro, specialization, try_from)]
 #![deny(missing_docs)]
 
 extern crate argon2rs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! Ruma is a Matrix homeserver client API.
 
-#![feature(proc_macro, specialization, try_from)]
+#![feature(proc_macro, try_from)]
 #![deny(missing_docs)]
 
 extern crate argon2rs;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -15,10 +15,21 @@ use error::ApiError;
 use room_membership::{RoomMembership, RoomMembershipOptions};
 use schema::profiles;
 
+/// A new Matrix profile, not yet saved.
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "profiles"]
+pub struct NewProfile {
+    /// The user's ID.
+    pub id: UserId,
+    /// The avatar url.
+    pub avatar_url: Option<String>,
+    /// The display name.
+    pub displayname: Option<String>,
+}
+
 /// A Matrix profile.
-#[derive(Debug, Clone, Identifiable, Queryable)]
-#[changeset_for(profiles)]
-#[insertable_into(profiles)]
+#[derive(AsChangeset, Debug, Clone, Identifiable, Queryable)]
+#[table_name = "profiles"]
 pub struct Profile {
     /// The user's ID.
     pub id: UserId,

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -15,20 +15,8 @@ use error::ApiError;
 use room_membership::{RoomMembership, RoomMembershipOptions};
 use schema::profiles;
 
-/// A new Matrix profile, not yet saved.
-#[derive(Debug, Clone, Insertable)]
-#[table_name = "profiles"]
-pub struct NewProfile {
-    /// The user's ID.
-    pub id: UserId,
-    /// The avatar url.
-    pub avatar_url: Option<String>,
-    /// The display name.
-    pub displayname: Option<String>,
-}
-
 /// A Matrix profile.
-#[derive(AsChangeset, Debug, Clone, Identifiable, Queryable)]
+#[derive(AsChangeset, Debug, Clone, Identifiable, Insertable, Queryable)]
 #[table_name = "profiles"]
 pub struct Profile {
     /// The user's ID.

--- a/src/room.rs
+++ b/src/room.rs
@@ -20,6 +20,11 @@ use ruma_events::room::join_rules::{
     JoinRulesEvent,
     JoinRulesEventContent,
 };
+use ruma_events::room::member::{
+    MemberEvent,
+    MemberEventContent,
+    MembershipState,
+};
 use ruma_events::room::name::{NameEvent, NameEventContent};
 use ruma_events::room::power_levels::{PowerLevelsEvent, PowerLevelsEventContent};
 use ruma_events::room::topic::{TopicEvent, TopicEventContent};
@@ -49,8 +54,8 @@ pub struct CreationOptions {
 }
 
 /// A new Matrix room, not yet saved.
-#[derive(Debug)]
-#[insertable_into(rooms)]
+#[derive(Debug, Insertable)]
+#[table_name = "rooms"]
 pub struct NewRoom {
     /// The room's unique ID.
     pub id: RoomId,
@@ -118,7 +123,6 @@ impl Room {
                 },
                 event_id: EventId::new(homeserver_domain)?,
                 event_type: EventType::RoomCreate,
-                extra_content: (),
                 prev_content: None,
                 room_id: room.id.clone(),
                 state_key: "".to_string(),
@@ -135,7 +139,6 @@ impl Room {
                     },
                     event_id: EventId::new(homeserver_domain)?,
                     event_type: EventType::RoomName,
-                    extra_content: (),
                     prev_content: None,
                     room_id: room.id.clone(),
                     state_key: "".to_string(),
@@ -153,7 +156,6 @@ impl Room {
                     },
                     event_id: EventId::new(homeserver_domain)?,
                     event_type: EventType::RoomTopic,
-                    extra_content: (),
                     prev_content: None,
                     room_id: room.id.clone(),
                     state_key: "".to_string(),
@@ -170,7 +172,6 @@ impl Room {
                 },
                 event_id: EventId::new(homeserver_domain)?,
                 event_type: EventType::RoomHistoryVisibility,
-                extra_content: (),
                 prev_content: None,
                 room_id: room.id.clone(),
                 state_key: "".to_string(),
@@ -186,7 +187,6 @@ impl Room {
                         content: JoinRulesEventContent { join_rule: JoinRule::Invite },
                         event_id: EventId::new(homeserver_domain)?,
                         event_type: EventType::RoomJoinRules,
-                        extra_content: (),
                         prev_content: None,
                         room_id: room.id.clone(),
                         state_key: "".to_string(),
@@ -201,7 +201,6 @@ impl Room {
                         content: JoinRulesEventContent { join_rule: JoinRule::Public },
                         event_id: EventId::new(homeserver_domain)?,
                         event_type: EventType::RoomJoinRules,
-                        extra_content: (),
                         prev_content: None,
                         room_id: room.id.clone(),
                         state_key: "".to_string(),
@@ -216,7 +215,6 @@ impl Room {
                         content: JoinRulesEventContent { join_rule: JoinRule::Invite },
                         event_id: EventId::new(homeserver_domain)?,
                         event_type: EventType::RoomJoinRules,
-                        extra_content: (),
                         prev_content: None,
                         room_id: room.id.clone(),
                         state_key: "".to_string(),

--- a/src/room.rs
+++ b/src/room.rs
@@ -20,11 +20,6 @@ use ruma_events::room::join_rules::{
     JoinRulesEvent,
     JoinRulesEventContent,
 };
-use ruma_events::room::member::{
-    MemberEvent,
-    MemberEventContent,
-    MembershipState,
-};
 use ruma_events::room::name::{NameEvent, NameEventContent};
 use ruma_events::room::power_levels::{PowerLevelsEvent, PowerLevelsEventContent};
 use ruma_events::room::topic::{TopicEvent, TopicEventContent};

--- a/src/room_alias.rs
+++ b/src/room_alias.rs
@@ -82,7 +82,6 @@ impl RoomAlias {
                 content: AliasesEventContent { aliases: ids },
                 event_id: EventId::new(homeserver_domain)?,
                 event_type: EventType::RoomAliases,
-                extra_content: (),
                 prev_content: None,
                 room_id: new_room_alias.room_id.clone(),
                 state_key: homeserver_domain.to_string(),

--- a/src/room_alias.rs
+++ b/src/room_alias.rs
@@ -25,8 +25,8 @@ use room::Room;
 use schema::{events, room_aliases, rooms};
 
 /// A new room alias, not yet saved.
-#[derive(Debug)]
-#[insertable_into(room_aliases)]
+#[derive(Debug, Insertable)]
+#[table_name = "room_aliases"]
 pub struct NewRoomAlias {
     /// The human-readable alias.
     pub alias: RoomAliasId,

--- a/src/room_membership.rs
+++ b/src/room_membership.rs
@@ -28,7 +28,7 @@ use ruma_events::room::member::{
     MemberEventContent,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
-use serde_json::{Error as SerdeJsonError, Value, from_value};
+use serde_json::{Value, from_value};
 
 use error::ApiError;
 use event::{NewEvent, Event};
@@ -267,7 +267,7 @@ impl RoomMembership {
         Ok(new_member_event)
     }
 
-    /// Return member event's for given `room_id`.
+    /// Return member events for given `room_id`.
     pub fn get_events_by_room(connection: &PgConnection, room_id: RoomId) -> Result<Vec<MemberEvent>, ApiError> {
         let event_ids = room_memberships::table
             .filter(room_memberships::room_id.eq(room_id))
@@ -281,9 +281,12 @@ impl RoomMembership {
                 _ => ApiError::from(err),
             })?;
 
-        let member_events: Result<Vec<MemberEvent>, SerdeJsonError> = events.into_iter()
-                                                                        .map(TryInto::try_into)
-                                                                        .collect();
+        let member_events: Result<Vec<MemberEvent>, SerdeJsonError> =
+            events
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect();
+
         member_events.map_err(ApiError::from)
     }
 }

--- a/src/room_membership.rs
+++ b/src/room_membership.rs
@@ -252,11 +252,11 @@ impl RoomMembership {
                 avatar_url: avatar_url,
                 displayname: displayname,
                 membership: membership,
-                third_party_invite: (),
+                third_party_invite: None,
             },
             event_id: event_id.clone(),
             event_type: EventType::RoomMember,
-            extra_content: MemberEventExtraContent { invite_room_state: None },
+            invite_room_state: None,
             prev_content: None,
             room_id: options.room_id.clone(),
             state_key: format!("@{}:{}", options.user_id.clone(), &homeserver_domain),
@@ -281,12 +281,6 @@ impl RoomMembership {
                 _ => ApiError::from(err),
             })?;
 
-        let member_events: Result<Vec<MemberEvent>, SerdeJsonError> =
-            events
-            .into_iter()
-            .map(TryInto::try_into)
-            .collect();
-
-        member_events.map_err(ApiError::from)
+        events.into_iter() .map(TryInto::try_into). collect()
     }
 }

--- a/src/room_membership.rs
+++ b/src/room_membership.rs
@@ -26,7 +26,6 @@ use ruma_events::room::member::{
     MemberEvent,
     MembershipState,
     MemberEventContent,
-    MemberEventExtraContent
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{Error as SerdeJsonError, Value, from_value};
@@ -51,8 +50,8 @@ pub struct RoomMembershipOptions {
 }
 
 /// A new Matrix room membership, not yet saved.
-#[derive(Debug, Clone)]
-#[insertable_into(room_memberships)]
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "room_memberships"]
 pub struct NewRoomMembership {
     /// The eventID.
     pub event_id: EventId,
@@ -67,8 +66,8 @@ pub struct NewRoomMembership {
 }
 
 /// A Matrix room membership.
-#[derive(Debug, Clone, Queryable)]
-#[changeset_for(room_memberships)]
+#[derive(AsChangeset, Debug, Clone, Queryable)]
+#[table_name = "room_memberships"]
 pub struct RoomMembership {
     /// The eventID.
     pub event_id: EventId,

--- a/src/server.rs
+++ b/src/server.rs
@@ -106,9 +106,9 @@ impl<'a> Server<'a> {
         r0_router.get("/rooms/:room_id/members", Members::chain(), "members");
         r0_router.get("/profile/:user_id", Profile::chain(), "profile");
         r0_router.get("/profile/:user_id/avatar_url", GetAvatarUrl::chain(), "get_avatar_url");
-        r0_router.get("/profile/:user_id/displayname", GetDisplayname::chain(), "get_displayname");
+        r0_router.get("/profile/:user_id/displayname", GetDisplayName::chain(), "get_display_name");
         r0_router.put("/profile/:user_id/avatar_url", PutAvatarUrl::chain(), "put_avatar_url");
-        r0_router.put("/profile/:user_id/displayname", PutDisplayname::chain(), "put_displayname");
+        r0_router.put("/profile/:user_id/displayname", PutDisplayName::chain(), "put_display_name");
 
         let mut r0 = Chain::new(r0_router);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,38 +62,53 @@ impl<'a> Server<'a> {
     ) -> Result<Server, CliError> {
         let mut r0_router = Router::new();
 
-        r0_router.post("/account/password", AccountPassword::chain());
-        r0_router.post("/account/deactivate", DeactivateAccount::chain());
-        r0_router.post("/createRoom", CreateRoom::chain());
-        r0_router.get("/directory/room/:room_alias", GetRoomAlias::chain());
-        r0_router.delete("/directory/room/:room_alias", DeleteRoomAlias::chain());
-        r0_router.put("/directory/room/:room_alias", PutRoomAlias::chain());
-        r0_router.post("/login", Login::chain());
-        r0_router.post("/logout", Logout::chain());
-        r0_router.post("/register", Register::chain());
-        r0_router.post("/tokenrefresh", unimplemented);
-        r0_router.put("/user/:user_id/account_data/:type", PutAccountData::chain());
-        r0_router.put("/user/:user_id/rooms/:room_id/account_data/:type", PutRoomAccountData::chain());
+        r0_router.post("/account/password", AccountPassword::chain(), "account_password");
+        r0_router.post("/account/deactivate", DeactivateAccount::chain(), "deactivate_account");
+        r0_router.post("/createRoom", CreateRoom::chain(), "create_room");
+        r0_router.get("/directory/room/:room_alias", GetRoomAlias::chain(), "get_room_alias");
+        r0_router.delete(
+            "/directory/room/:room_alias",
+            DeleteRoomAlias::chain(),
+            "delete_room_alias",
+        );
+        r0_router.put("/directory/room/:room_alias", PutRoomAlias::chain(), "put_room_alias");
+        r0_router.post("/login", Login::chain(), "login");
+        r0_router.post("/logout", Logout::chain(), "logout");
+        r0_router.post("/register", Register::chain(), "register");
+        r0_router.post("/tokenrefresh", unimplemented, "token_refresh");
+        r0_router.put(
+            "/user/:user_id/account_data/:type",
+            PutAccountData::chain(),
+            "put_account_data",
+        );
+        r0_router.put(
+            "/user/:user_id/rooms/:room_id/account_data/:type",
+            PutRoomAccountData::chain(),
+            "put_room_account_data",
+        );
         r0_router.put(
             "/rooms/:room_id/send/:event_type/:transaction_id",
             SendMessageEvent::chain(),
+            "send_message_event",
         );
         r0_router.put(
             "/rooms/:room_id/state/:event_type",
             StateMessageEvent::chain(),
+            "state_message_event",
         );
         r0_router.put(
             "/rooms/:room_id/state/:event_type/:state_key",
             StateMessageEvent::chain(),
+            "state_message_event_with_key",
         );
-        r0_router.post("/rooms/:room_id/join", JoinRoom::chain());
-        r0_router.post("/rooms/:room_id/invite", InviteToRoom::chain());
-        r0_router.get("/rooms/:room_id/members", Members::chain());
-        r0_router.get("/profile/:user_id", Profile::chain());
-        r0_router.get("/profile/:user_id/avatar_url", GetAvatarUrl::chain());
-        r0_router.get("/profile/:user_id/displayname", GetDisplayName::chain());
-        r0_router.put("/profile/:user_id/avatar_url", PutAvatarUrl::chain());
-        r0_router.put("/profile/:user_id/displayname", PutDisplayName::chain());
+        r0_router.post("/rooms/:room_id/join", JoinRoom::chain(), "join_room");
+        r0_router.post("/rooms/:room_id/invite", InviteToRoom::chain(), "invite_to_room");
+        r0_router.get("/rooms/:room_id/members", Members::chain(), "members");
+        r0_router.get("/profile/:user_id", Profile::chain(), "profile");
+        r0_router.get("/profile/:user_id/avatar_url", GetAvatarUrl::chain(), "get_avatar_url");
+        r0_router.get("/profile/:user_id/displayname", GetDisplayname::chain(), "get_displayname");
+        r0_router.put("/profile/:user_id/avatar_url", PutAvatarUrl::chain(), "put_avatar_url");
+        r0_router.put("/profile/:user_id/displayname", PutDisplayname::chain(), "put_displayname");
 
         let mut r0 = Chain::new(r0_router);
 
@@ -119,7 +134,7 @@ impl<'a> Server<'a> {
 
         let mut versions_router = Router::new();
 
-        versions_router.get("/versions", Versions::new(vec!["r0.0.1"]));
+        versions_router.get("/versions", Versions::new(vec!["r0.0.1"]), "versions");
 
         let mut versions = Chain::new(versions_router);
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -20,8 +20,8 @@ use error::ApiError;
 use schema::users;
 
 /// A Matrix user.
-#[derive(Debug, Clone, Identifiable, Queryable)]
-#[changeset_for(users)]
+#[derive(AsChangeset, Debug, Clone, Identifiable, Queryable)]
+#[table_name = "users"]
 pub struct User {
     /// The user's unique ID.
     pub id: UserId,
@@ -36,8 +36,8 @@ pub struct User {
 }
 
 /// A new Matrix user, not yet saved.
-#[derive(Debug)]
-#[insertable_into(users)]
+#[derive(Debug, Insertable)]
+#[table_name = "users"]
 pub struct NewUser {
     /// The user's unique ID.
     pub id: UserId,


### PR DESCRIPTION
Not long ago I made a big change to ruma-events that turns `Event`, `RoomEvent`, and `StateEvent` into traits (instead of generic structs). I've been having a really hard time integrating this new version of ruma-events back into Ruma, so I am hoping for some help figuring out the compiler errors. Some of the errors I understand and just haven't bothered with yet, and some I can't figure out how to solve. In particular, the ones of this kind:

```
the trait `std::convert::From<<event::NewEvent as std::convert::TryFrom<ruma_events::call::answer::AnswerEvent>>::Err>` is not implemented for `error::ApiError`
```

I'm also not sure that changing the event kinds to traits was even a beneficial change. I outlined my reasoning for wanting them to be traits in https://github.com/rust-lang/rfcs/pull/1546#issuecomment-246568198, but maybe that actually makes the library harder to work with and I should revert the change.

Thoughts and/or help appreciated!

/cc @ruma/contributors

Edit: I forgot to mention that this PR unfortunately also includes macros 1.1 changes and the stabilization of the question mark operator. The parts that are relevant to the trait-based events should be pretty obvious, though.