### PR TITLE
Add tests for the invite list

### DIFF
--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -260,7 +260,7 @@ impl Room {
 
                 if missing_user_ids.len() > 0 {
                     return Err(
-                        ApiError::unknown(Some(&format!(
+                        ApiError::bad_json(Some(&format!(
                             "Unknown users in invite list: {}",
                             &missing_user_ids
                                 .iter()


### PR DESCRIPTION
Small test coverage improvement by including the case where the invited users are not registered.

Added an extra assert to test whether a room alias was indeed created.