### PR TITLE
Response from the Versions endpoint is incorrect

### DIFF
--- a/src/api/r0/versions.rs
+++ b/src/api/r0/versions.rs
@@ -5,21 +5,24 @@ use iron::{Handler, IronResult, Request, Response, status};
 use modifier::SerializableResponse;
 
 /// The /versions endpoint.
+#[derive(Serialize)]
 pub struct Versions {
     versions: Vec<&'static str>,
 }
 
 impl Versions {
-    /// Create a `Versions` offering support for the specified versions of the Matrix spec.
-    pub fn new(versions: Vec<&'static str>) -> Versions {
+    /// Returns the list of supported `Versions` of the Matrix spec.
+    pub fn supported() -> Self {
         Versions {
-            versions: versions,
+            versions: vec![
+                "r0.2.0"
+            ]
         }
     }
 }
 
 impl Handler for Versions {
     fn handle(&self, _request: &mut Request) -> IronResult<Response> {
-        Ok(Response::with((status::Ok, SerializableResponse(&self.versions))))
+        Ok(Response::with((status::Ok, SerializableResponse(&self))))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -134,7 +134,7 @@ impl<'a> Server<'a> {
 
         let mut versions_router = Router::new();
 
-        versions_router.get("/versions", Versions::new(vec!["r0.0.1"]), "versions");
+        versions_router.get("/versions", Versions::supported(), "versions");
 
         let mut versions = Chain::new(versions_router);
 


### PR DESCRIPTION
Originally the response returned as 
```
["r0.0.1"]
```
where the spec defines it to return as
```
{
    "versions": ["r0.0.1"]
}
```
This should fix that. However, I have another question, is the expectation that ruma will support all versions of the spec? At the very least I believe it should be supporting the most recent one. Let me know and I can modify or add as needed. 