### PR TITLE
Removing duplication in Clap app specification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,9 @@ embed_migrations!();
 fn main() {
     env_logger::init().expect("Failed to initialize logger.");
 
-    let matches = App::new("ruma")
+    let matches = App::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
-        .about("A Matrix homeserver client API")
+        .about(env!("CARGO_PKG_DESCRIPTION"))
         .setting(AppSettings::GlobalVersion)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(


### PR DESCRIPTION
I noticed that both the name and the description were duplicates of the ones specified in Cargo.toml. I figure it makes sense for them to be driven by those values so I made the change. Let me know what you think. (There's also a mild amount of OCD in there in moving name and version to the top 😛 )