### PR TITLE
Add support for the initial_state parameter

### DIFF
--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -92,8 +92,9 @@ impl Event {
         -> Result<JoinRulesEvent, ApiError>
     {
         let event: Event = events::table
-            .filter(events::event_type.eq((&EventType::RoomJoinRules).to_string()))
+            .filter(events::event_type.eq(EventType::RoomJoinRules.to_string()))
             .filter(events::room_id.eq(room_id))
+            .order(events::ordering.desc())
             .first(connection)
             .map_err(|err| match err {
                 DieselError::NotFound => ApiError::not_found(None),

--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -98,17 +98,6 @@ impl Room {
                 .get_result(connection)
                 .map_err(ApiError::from)?;
 
-            if let Some(ref alias) = creation_options.alias {
-                let new_room_alias = NewRoomAlias {
-                    alias: RoomAliasId::try_from(&format!("#{}:{}", alias, homeserver_domain))?,
-                    room_id: room.id.clone(),
-                    user_id: new_room.user_id.clone(),
-                    servers: vec![homeserver_domain.to_string()],
-                };
-
-                RoomAlias::create(connection, homeserver_domain, &new_room_alias)?;
-            }
-
             let mut new_events = Vec::new();
 
             let new_create_event: NewEvent = CreateEvent {
@@ -225,6 +214,17 @@ impl Room {
                 .into(events::table)
                 .execute(connection)
                 .map_err(ApiError::from)?;
+
+            if let Some(ref alias) = creation_options.alias {
+                let new_room_alias = NewRoomAlias {
+                    alias: RoomAliasId::try_from(&format!("#{}:{}", alias, homeserver_domain))?,
+                    room_id: room.id.clone(),
+                    user_id: new_room.user_id.clone(),
+                    servers: vec![homeserver_domain.to_string()],
+                };
+
+                RoomAlias::create(connection, homeserver_domain, &new_room_alias)?;
+            }
 
             if let Some(ref invite_list) = creation_options.invite_list {
                 room.create_memberships(connection, &invite_list, homeserver_domain)?;

--- a/src/test.rs
+++ b/src/test.rs
@@ -212,6 +212,11 @@ impl Test {
         self.post(&path, &body)
     }
 
+    /// Look up a `RoomId` using an alias.
+    pub fn get_room_by_alias(&self, alias: &str) -> Response {
+        self.get(&format!("/_matrix/client/r0/directory/room/{}", alias))
+    }
+
     /// Join an existent room.
     pub fn join_room(&self, access_token: &str, room_id: &str) -> Response {
         let join_path = format!(


### PR DESCRIPTION
I am using, temporarily, my fork with the missing stripped state events just to make this work but I get the following error when ruma tries to deserialize one of the stripped events.

```
Can't parse body to the struct
Some(Syntax(InvalidType(Map), 0, 0)) 
```
Any ideas on what might be causing this error?