### PR TITLE
Update IronError::new calls to use IronError::from for ApiError

### DIFF
--- a/src/api/r0/account.rs
+++ b/src/api/r0/account.rs
@@ -42,9 +42,7 @@ impl Handler for AccountPassword {
         {
             Ok(Some(account_password_request)) => account_password_request,
             Ok(None) | Err(_) => {
-                let error = ApiError::not_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::not_json(None)));
             }
         };
 
@@ -57,9 +55,7 @@ impl Handler for AccountPassword {
         let connection = DB::from_request(request)?;
 
         if let Err(_) = user.save_changes::<User>(&*connection) {
-            let error = ApiError::unauthorized(None);
-
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(ApiError::unauthorized(None)));
         }
 
         Ok(Response::with(Status::Ok))
@@ -81,7 +77,7 @@ impl Handler for DeactivateAccount {
                 .expect("AccessTokenAuth should ensure an access token");
 
             if let Err(error) = token.revoke(&connection) {
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             };
         }
 
@@ -89,7 +85,7 @@ impl Handler for DeactivateAccount {
             .expect("AccessTokenAuth should ensure a user");
 
         if let Err(error) = user.deactivate(&connection) {
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(error));
         };
 
         // Delete all the account data associated with the user.
@@ -122,7 +118,7 @@ impl Handler for PutAccountData {
                 "The given user_id does not correspond to the authenticated user".to_string()
             );
 
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(error));
         }
 
         let data_type = request.extensions.get::<DataTypeParam>()
@@ -133,7 +129,7 @@ impl Handler for PutAccountData {
             Ok(None) | Err(_) => {
                 let error = ApiError::bad_json(None);
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -171,7 +167,7 @@ impl Handler for PutRoomAccountData {
                 "The given user_id does not correspond to the authenticated user".to_string()
             );
 
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(error));
         }
 
         let room_id = request.extensions.get::<RoomIdParam>()
@@ -184,17 +180,17 @@ impl Handler for PutRoomAccountData {
             .map_err(IronError::from)?;
 
         if entry.is_none() {
-            let err = ApiError::unauthorized(
+            let error = ApiError::unauthorized(
                 "No membership entry was found.".to_string()
             );
 
-            return Err(IronError::new(err.clone(), err));
+            return Err(IronError::from(error));
         }
 
         if entry.unwrap().membership != "join" {
-            let err = ApiError::unauthorized("The room is not accesible.".to_string());
+            let error = ApiError::unauthorized("The room is not accesible.".to_string());
 
-            return Err(IronError::new(err.clone(), err));
+            return Err(IronError::from(error));
         }
 
         let data_type = request.extensions.get::<DataTypeParam>()
@@ -203,9 +199,7 @@ impl Handler for PutRoomAccountData {
         let content = match request.get::<bodyparser::Json>() {
             Ok(Some(content)) => content.to_string().clone(),
             Ok(None) | Err(_) => {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         };
 

--- a/src/api/r0/directory.rs
+++ b/src/api/r0/directory.rs
@@ -68,7 +68,7 @@ impl Handler for DeleteRoomAlias {
                 "Provided room alias did not exist or you do not have access to delete it.".to_string()
             );
 
-            Err(IronError::new(error.clone(), error))
+            Err(IronError::from(error))
         }
     }
 }
@@ -94,9 +94,7 @@ impl Handler for PutRoomAlias {
         let room_id = if let Ok(Some(api_request)) = parsed_request {
             RoomId::try_from(&api_request.room_id).map_err(ApiError::from)?
         } else {
-            let error = ApiError::bad_json(None);
-
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(ApiError::bad_json(None)));
         };
 
         let user = request.extensions.get::<User>()

--- a/src/api/r0/event_creation.rs
+++ b/src/api/r0/event_creation.rs
@@ -149,7 +149,7 @@ impl Handler for SendMessageEvent {
                     format!("Events of type {} cannot be created with this API.", event_type)
                 );
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -353,7 +353,7 @@ impl Handler for StateMessageEvent {
                     format!("Events of type {} cannot be created with this API.", event_type)
                 );
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -398,7 +398,7 @@ fn ensure_empty_state_key(state_key: &str, event_type: &EventType) -> Result<(),
     } else {
         let error = ApiError::bad_event(format!("Events of type {} must have an empty state key.", event_type));
 
-        Err(IronError::new(error.clone(), error))
+        Err(IronError::from(error))
     }
 }
 

--- a/src/api/r0/profile.rs
+++ b/src/api/r0/profile.rs
@@ -47,7 +47,7 @@ impl Handler for Profile {
                     format!("No profile found for {}", user_id)
                 );
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -90,7 +90,7 @@ impl Handler for GetAvatarUrl {
                             format!("No avatar_url found for {}", user_id)
                         );
 
-                        return Err(IronError::new(error.clone(), error));
+                        return Err(IronError::from(error));
                     }
                 }
             }
@@ -99,7 +99,7 @@ impl Handler for GetAvatarUrl {
                     format!("No profile found for {}", user_id)
                 );
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -122,9 +122,7 @@ impl Handler for PutAvatarUrl {
         let avatar_url_request = match request.get::<bodyparser::Struct<PutAvatarUrlResquest>>() {
             Ok(Some(avatar_url_request)) => avatar_url_request,
             Ok(None) | Err(_) => {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         };
 
@@ -142,7 +140,7 @@ impl Handler for PutAvatarUrl {
                 "The given user_id does not correspond to the authenticated user".to_string()
             );
 
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(error));
         }
 
         DataProfile::update_avatar_url(
@@ -192,7 +190,7 @@ impl Handler for GetDisplayName {
                             format!("No displayname found for {}", user_id)
                         );
 
-                        return Err(IronError::new(error.clone(), error));
+                        return Err(IronError::from(error));
                     }
                 }
             }
@@ -201,7 +199,7 @@ impl Handler for GetDisplayName {
                     format!("No profile found for {}", user_id)
                 );
 
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(error));
             }
         };
 
@@ -224,9 +222,7 @@ impl Handler for PutDisplayName {
         let displayname_request = match request.get::<bodyparser::Struct<PutDisplayNameRequest>>() {
             Ok(Some(displayname_request)) => displayname_request,
             Ok(None) | Err(_) => {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         };
 
@@ -244,7 +240,7 @@ impl Handler for PutDisplayName {
                 "The given user_id does not correspond to the authenticated user".to_string()
             );
 
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(error));
         }
 
         DataProfile::update_displayname(

--- a/src/api/r0/registration.rs
+++ b/src/api/r0/registration.rs
@@ -69,18 +69,14 @@ impl Handler for Register {
         let registration_request = match request.get::<bodyparser::Struct<RegistrationRequest>>() {
             Ok(Some(registration_request)) => registration_request,
             Ok(None) | Err(_) => {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         };
 
         if let Some(kind) = registration_request.kind {
             match kind {
                 RegistrationKind::Guest => {
-                    let error = ApiError::guest_forbidden(None);
-
-                    return Err(IronError::new(error.clone(), error));
+                    return Err(IronError::from(ApiError::guest_forbidden(None)));
                 }
                 _ => {},
             }

--- a/src/api/r0/room_creation.rs
+++ b/src/api/r0/room_creation.rs
@@ -48,9 +48,7 @@ impl CreateRoomRequest {
     pub fn validate(self) -> Result<Self, IronError> {
         if let Some(ref visibility) = self.visibility {
             if visibility != "public" && visibility != "private" {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         }
 
@@ -65,9 +63,7 @@ impl Handler for CreateRoom {
         let create_room_request = match request.get::<bodyparser::Struct<CreateRoomRequest>>() {
             Ok(Some(create_room_request)) => create_room_request.validate()?,
             Ok(None) | Err(_) => {
-                let error = ApiError::bad_json(None);
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::bad_json(None)));
             }
         };
 

--- a/src/middleware/authentication.rs
+++ b/src/middleware/authentication.rs
@@ -48,7 +48,7 @@ impl BeforeMiddleware for AccessTokenAuth {
             }
         }
 
-        Err(IronError::new(ApiError::unauthorized(None), ApiError::unauthorized(None)))
+        Err(IronError::from(ApiError::unauthorized(None)))
     }
 }
 
@@ -79,7 +79,7 @@ impl BeforeMiddleware for UIAuth {
             }
         }
 
-        Err(IronError::new(ApiError::unauthorized(None), ApiError::unauthorized(None)))
+        Err(IronError::from(ApiError::unauthorized(None)))
     }
 }
 

--- a/src/middleware/json.rs
+++ b/src/middleware/json.rs
@@ -20,17 +20,13 @@ impl BeforeMiddleware for JsonRequest {
             Mime(TopLevel::Application, SubLevel::Json, _) => Some(()),
             _ => None,
         }).is_none() {
-            let error = ApiError::wrong_content_type(None);
-
-            return Err(IronError::new(error.clone(), error));
+            return Err(IronError::from(ApiError::wrong_content_type(None)));
         }
 
         match request.get::<bodyparser::Json>() {
             Ok(Some(_)) => Ok(()),
             Ok(_) | Err(_) => {
-                let error = ApiError::not_json(None);
-
-                Err(IronError::new(error.clone(), error))
+                Err(IronError::from(ApiError::not_json(None)))
             },
         }
     }

--- a/src/middleware/path_params.rs
+++ b/src/middleware/path_params.rs
@@ -114,9 +114,7 @@ impl BeforeMiddleware for RoomAliasIdParam {
                 room_alias_id
             }
             None => {
-                let error = ApiError::missing_param("room_alias");
-
-                return Err(IronError::new(error.clone(), error));
+                return Err(IronError::from(ApiError::missing_param("room_alias")));
             }
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -171,7 +171,5 @@ impl<'a> Server<'a> {
 }
 
 fn unimplemented(_request: &mut Request) -> IronResult<Response> {
-    let error = ApiError::unimplemented(None);
-
-    Err(IronError::new(error.clone(), error))
+    Err(IronError::from(ApiError::unimplemented(None)))
 }


### PR DESCRIPTION
I noticed there were quite a few locations using IronError::new(error.clone(), error) to convert ApiErrors to IronErrors even though someone had already implemented the From<ApiError> for IronError trait so I went ahead and updated all of the call sites to use the improved instantiation.