### PR TITLE
Use the event_type field to find power_level events

### DIFF
--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -295,7 +295,7 @@ impl Room {
     -> Result<PowerLevelsEventContent, ApiError> {
         match events::table
             .filter(events::room_id.eq(self.id.clone()))
-            .filter(events::state_key.eq(EventType::RoomPowerLevels.to_string()))
+            .filter(events::event_type.eq(EventType::RoomPowerLevels.to_string()))
             .order(events::ordering.desc())
             .first::<Event>(connection)
         {


### PR DESCRIPTION
Subtle bug that appeared when non-default power levels were set. Currently the query doesn't find anything and always returns the defaults.