### PR TITLE
Add /room/:room_id/state

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -110,7 +110,7 @@ Legend:
     <th align="left" colspan="3">Getting events for a room</th>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:white_check_mark:</td>
     <td><a href="https://github.com/ruma/ruma/issues/9">#9</a></td>
     <td>GET /rooms/:room_id/state</td>
   </tr>

--- a/src/api/r0/event_creation.rs
+++ b/src/api/r0/event_creation.rs
@@ -598,19 +598,16 @@ mod tests {
         );
 
         let event_content = format!(r#"{{
-                                    "ban": 100,"events": {{
-                                        "m.room.message": 100
-                                    }},
-                                    "events_default": 0,
-                                    "invite": 100,
-                                    "kick": 100,
-                                    "redact": 0,
-                                    "state_default": 0,
-                                    "users": {{
-                                        "{}": 50
-                                    }},
-                                    "users_default": 0
-                                    }}"#, bob.id);
+            "ban": 100,
+            "events": {{ "m.room.message": 100 }},
+            "events_default": 0,
+            "invite": 100,
+            "kick": 100,
+            "redact": 0,
+            "state_default": 0,
+            "users": {{ "{}": 50 }},
+            "users_default": 0
+        }}"#, bob.id);
 
         let response = test.put(&state_event_path, &event_content);
         assert_eq!(response.status, Status::Ok);
@@ -623,20 +620,16 @@ mod tests {
         );
 
         let event_content = format!(r#"{{
-                                    "ban": 100,
-                                    "events": {{
-                                        "m.room.message": 0
-                                    }},
-                                    "events_default": 0,
-                                    "invite": 100,
-                                    "kick": 100,
-                                    "redact": 0,
-                                    "state_default": 0,
-                                    "users": {{
-                                        "{}": 50
-                                    }},
-                                    "users_default": 0
-                                    }}"#, bob.id);
+            "ban": 100,
+            "events": {{ "m.room.message": 0 }},
+            "events_default": 0,
+            "invite": 100,
+            "kick": 100,
+            "redact": 0,
+            "state_default": 0,
+            "users": {{ "{}": 50 }},
+            "users_default": 0
+        }}"#, bob.id);
 
         // Now everyone can send messages
         let response = test.put(&state_event_path, &event_content);

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -16,6 +16,7 @@ pub use self::presence::{GetPresenceList, GetPresenceStatus, PostPresenceList, P
 pub use self::profile::{Profile, GetAvatarUrl, PutAvatarUrl, GetDisplayName, PutDisplayName};
 pub use self::registration::Register;
 pub use self::room_creation::CreateRoom;
+pub use self::room_info::RoomState;
 pub use self::tags::{DeleteTag, GetTags, PutTag};
 pub use self::sync::Sync;
 pub use self::versions::Versions;
@@ -33,6 +34,7 @@ mod presence;
 mod profile;
 mod registration;
 mod room_creation;
+mod room_info;
 mod tags;
 mod sync;
 mod versions;

--- a/src/api/r0/room_info.rs
+++ b/src/api/r0/room_info.rs
@@ -1,0 +1,355 @@
+//! Endpoint for retrieving the state of a room.
+
+use std::convert::TryInto;
+
+use iron::{Chain, Handler, IronResult, Request, Response};
+use iron::status::Status;
+use ruma_events::collections::all::StateEvent;
+
+use db::DB;
+use error::ApiError;
+use middleware::{AccessTokenAuth, MiddlewareChain, RoomIdParam};
+use models::event::Event;
+use models::room::Room;
+use models::room_membership::RoomMembership;
+use models::user::User;
+use modifier::SerializableResponse;
+
+/// The `/rooms/:room_id/state` endpoint.
+pub struct RoomState;
+
+middleware_chain!(RoomState, [RoomIdParam, AccessTokenAuth]);
+
+impl Handler for RoomState {
+    fn handle(&self, request: &mut Request) -> IronResult<Response> {
+        let user = request.extensions.get::<User>()
+            .expect("AccessTokenAuth should ensure a user").clone();
+
+        let room_id = request.extensions.get::<RoomIdParam>()
+            .expect("RoomIdParam should ensure a room_id").clone();
+
+        let connection = DB::from_request(request)?;
+
+        let room = match Room::find(&connection, &room_id)? {
+            Some(room) => room,
+            None => {
+                Err(ApiError::unauthorized("The room was not found on this server".to_string()))?
+            }
+        };
+
+        let membership = RoomMembership::find(&connection, &room.id, &user.id)?;
+
+        if membership.is_none() {
+            Err(ApiError::unauthorized("The user is not a member of the room".to_string()))?
+        }
+
+        let membership_state = membership.clone().unwrap().membership;
+        let mut events = Vec::<Event>::new();
+
+        match membership_state.as_ref() {
+            "join" => {
+                events.append(
+                    &mut Event::get_room_state_events_until(&connection, &room_id, None)?
+                );
+            },
+            "leave" => {
+                let last_event = Event::find(&connection, &membership.unwrap().event_id)?;
+
+                events.append(
+                    &mut Event::get_room_state_events_until(&connection, &room_id, last_event)?
+                );
+            },
+            _ => {}
+        }
+
+        let mut state_events: Vec<StateEvent> = Vec::new();
+
+        for event in events {
+            state_events.push(event.try_into()?);
+        }
+
+        Ok(Response::with((Status::Ok, SerializableResponse(state_events))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test::Test;
+    use iron::status::Status;
+    use serde_json::Value;
+
+    #[test]
+    fn forbidden_for_non_members() {
+        let test = Test::new();
+        let alice = test.create_user();
+        let bob = test.create_user();
+
+        let room_id = test.create_public_room(&alice.token);
+
+        let room_state_path = format!(
+            "/_matrix/client/r0/rooms/{}/state?access_token={}",
+            room_id,
+            bob.token
+        );
+
+        assert_eq!(test.get(&room_state_path).status, Status::Forbidden);
+    }
+
+    #[test]
+    fn all_the_events_are_retrieved() {
+        let test = Test::new();
+        let alice = test.create_user();
+
+        let room_options = r##"{
+            "initial_state": [{
+                "state_key": "",
+                "type": "m.room.aliases",
+                "content": { "aliases": ["#alias_1:ruma.test"] }
+            }, {
+                "state_key": "",
+                "type": "m.room.topic",
+                "content": { "topic": "Test Topic" }
+            }, {
+                "state_key": "",
+                "type": "m.room.name",
+                "content": { "name": "Test Name" }
+            }, {
+                "state_key": "",
+                "type": "m.room.canonical_alias",
+                "content": { "alias": "#canonical_alias:ruma.test" }
+            }]
+        }"##;
+
+        let room_id = test.create_room_with_params(&alice.token, &room_options);
+
+        let room_state_path = format!(
+            "/_matrix/client/r0/rooms/{}/state?access_token={}",
+            room_id,
+            alice.token
+        );
+
+        let response = test.get(&room_state_path);
+        assert_eq!(response.status, Status::Ok);
+
+        let events = response.json().as_array().unwrap();
+        assert!(events.len() > 0);
+
+        for e in events.iter() {
+            match e.find("type").unwrap().as_str().unwrap() {
+                "m.room.aliases" => {
+                    assert!(
+                        e.find_path(&["content", "aliases"]).unwrap()
+                        .as_array().unwrap()
+                        .contains(&Value::String("#alias_1:ruma.test".to_string()))
+                    );
+                },
+                "m.room.canonical_alias" => {
+                    assert_eq!(
+                        e.find_path(&["content", "alias"]).unwrap().as_str().unwrap(),
+                        "#canonical_alias:ruma.test"
+                    );
+                },
+                "m.room.create" => {
+                    assert_eq!(
+                        e.find_path(&["content", "creator"]).unwrap().as_str().unwrap(),
+                        alice.id
+                    );
+
+                    assert_eq!(
+                        e.find_path(&["content", "federate"]).unwrap().as_bool().unwrap(),
+                        true
+                    );
+                },
+                "m.room.history_visibility" => {
+                    assert_eq!(
+                        e.find_path(&["content", "history_visibility"]).unwrap().as_str().unwrap(),
+                        "shared"
+                    );
+                },
+                "m.room.join_rules" => {
+                    assert_eq!(
+                        e.find_path(&["content", "join_rule"]).unwrap().as_str().unwrap(),
+                        "invite"
+                    );
+                },
+                "m.room.member" => {
+                    assert_eq!(
+                        e.find_path(&["content", "membership"]).unwrap().as_str().unwrap(),
+                        "join"
+                    );
+
+                    assert_eq!(
+                        e.find("sender").unwrap().as_str().unwrap(),
+                        format!("{}", alice.id)
+                    );
+                },
+                "m.room.name" => {
+                    assert_eq!(
+                        e.find_path(&["content", "name"]).unwrap().as_str().unwrap(),
+                        "Test Name"
+                    );
+                },
+                "m.room.power_levels" => {
+                    let ban = e.find_path(&["content", "ban"]).unwrap().as_u64().unwrap();
+                    let invite = e.find_path(&["content", "invite"]).unwrap().as_u64().unwrap();
+                    let users = e.find_path(&["content", "users"]).unwrap().as_object().unwrap();
+                    let creator = e.find("sender").unwrap().as_str().unwrap();
+
+                    // Admin rights.
+                    assert_eq!(users.get(&alice.id).unwrap(), &Value::U64(100));
+                    assert_eq!(creator, alice.id);
+
+                    // The default values.
+                    assert_eq!(ban, 50);
+                    assert_eq!(invite, 50);
+                },
+                "m.room.topic" => {
+                    assert_eq!(
+                        e.find_path(&["content", "topic"]).unwrap().as_str().unwrap(),
+                        "Test Topic"
+                    );
+                },
+                _ =>  assert!(false)
+            }
+        }
+    }
+
+    #[test]
+    fn only_the_latest_events_are_retrieved() {
+        let test = Test::new();
+        let alice = test.create_user();
+        let room_options = r#"{"room_alias_name":"alias_1"}"#;
+        let room_id = test.create_room_with_params(&alice.token, &room_options);
+
+        let put_room_alias_path = format!(
+            "/_matrix/client/r0/directory/room/alias_2?access_token={}",
+            alice.token
+        );
+
+        let put_room_alias_body = format!(r#"{{"room_id": "{}"}}"#, room_id);
+
+        assert_eq!(
+            test.put(&put_room_alias_path, &put_room_alias_body).status,
+            Status::Ok
+        );
+
+        let room_state_path = format!(
+            "/_matrix/client/r0/rooms/{}/state?access_token={}",
+            room_id,
+            alice.token
+        );
+
+        let response = test.get(&room_state_path);
+        assert_eq!(response.status, Status::Ok);
+
+        let events = response.json().as_array().unwrap();
+        assert!(events.len() > 0);
+
+        for e in events.iter() {
+            match e.find("type").unwrap().as_str().unwrap() {
+                "m.room.aliases" => {
+                    let aliases = e.find_path(&["content", "aliases"]).unwrap().as_array().unwrap();
+
+                    assert!(aliases.contains(&Value::String("#alias_1:ruma.test".to_string())));
+                    assert!(aliases.contains(&Value::String("#alias_2:ruma.test".to_string())));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn previous_state_for_users_that_left() {
+        let test = Test::new();
+        let alice = test.create_user();
+        let bob = test.create_user();
+
+        let room_options = format!(r#"{{
+            "invite": ["{}"],
+            "initial_state": [{{
+                "state_key": "",
+                "type": "m.room.topic",
+                "content": {{ "topic": "Topic for Bob" }}
+            }}]
+        }}"#, bob.id);
+
+        let room_id = test.create_room_with_params(&alice.token, &room_options);
+
+        assert_eq!(test.join_room(&bob.token, &room_id).status, Status::Ok);
+
+        let bob_room_state_path = format!(
+            "/_matrix/client/r0/rooms/{}/state?access_token={}",
+            room_id,
+            bob.token
+        );
+
+        let response = test.get(&bob_room_state_path);
+        assert_eq!(response.status, Status::Ok);
+
+        let events = response.json().as_array().unwrap();
+        assert!(events.len() > 0);
+
+        for e in events.iter() {
+            match e.find("type").unwrap().as_str().unwrap() {
+                "m.room.topic" => {
+                    assert_eq!(
+                        e.find_path(&["content", "topic"]).unwrap().as_str().unwrap(),
+                        "Topic for Bob"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(test.leave_room(&bob.token, &room_id).status, Status::Ok);
+
+        // Alice updates the topic.
+        let event_content = r#"{"topic": "Topic for Alice"}"#;
+        let response = test.send_state_event(&alice.token, &room_id, "m.room.topic", &event_content);
+        assert_eq!(response.status, Status::Ok);
+
+        // Bob can't see the changes.
+        let response = test.get(&bob_room_state_path);
+        assert_eq!(response.status, Status::Ok);
+
+        let events = response.json().as_array().unwrap();
+        assert!(events.len() > 0);
+
+        for e in events.iter() {
+            match e.find("type").unwrap().as_str().unwrap() {
+                "m.room.topic" => {
+                    assert_eq!(
+                        e.find_path(&["content", "topic"]).unwrap().as_str().unwrap(),
+                        "Topic for Bob"
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        // Alice can see them...
+        let alice_room_state_path = format!(
+            "/_matrix/client/r0/rooms/{}/state?access_token={}",
+            room_id,
+            alice.token
+        );
+
+        let response = test.get(&alice_room_state_path);
+        assert_eq!(response.status, Status::Ok);
+
+        let events = response.json().as_array().unwrap();
+        assert!(events.len() > 0);
+
+        for e in events.iter() {
+            match e.find("type").unwrap().as_str().unwrap() {
+                "m.room.topic" => {
+                    assert_eq!(
+                        e.find_path(&["content", "topic"]).unwrap().as_str().unwrap(),
+                        "Topic for Alice"
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,6 +40,7 @@ use api::r0::{
     PutRoomAlias,
     PutTag,
     Register,
+    RoomState,
     SendMessageEvent,
     StateMessageEvent,
     Sync,
@@ -120,6 +121,7 @@ impl<'a> Server<'a> {
         r0_router.post("/join/:room_id_or_alias", JoinRoomWithIdOrAlias::chain(), "join_room_with_alias");
         r0_router.post("rooms/:room_id/leave", LeaveRoom::chain(), "leave_room");
         r0_router.get("/rooms/:room_id/members", Members::chain(), "members");
+        r0_router.get("/rooms/:room_id/state", RoomState::chain(), "get_room_state");
         r0_router.get("/profile/:user_id", Profile::chain(), "profile");
         r0_router.get("/profile/:user_id/avatar_url", GetAvatarUrl::chain(), "get_avatar_url");
         r0_router.get("/profile/:user_id/displayname", GetDisplayName::chain(), "get_display_name");

--- a/src/test.rs
+++ b/src/test.rs
@@ -248,6 +248,17 @@ impl Test {
         self.post(&join_path, r"{}")
     }
 
+    /// Leave a room.
+    pub fn leave_room(&self, access_token: &str, room_id: &str) -> Response {
+        let leave_room_path = format!(
+            "/_matrix/client/r0/rooms/{}/leave?access_token={}",
+            room_id,
+            access_token
+        );
+
+        self.post(&leave_room_path, "{}")
+    }
+
     /// Create tag
     pub fn create_tag(&self, access_token: &str, room_id: &str, user_id: &str, tag: &str, content: &str) {
         let put_tag_path = format!(
@@ -291,6 +302,24 @@ impl Test {
         );
         let body = format!(r#"{{"body":"{}","msgtype":"m.text"}}"#, message);
         self.put(&create_event_path, &body)
+    }
+
+    /// Send a state event to a room.
+    pub fn send_state_event(
+        &self,
+        access_token: &str,
+        room_id: &str,
+        event_type: &str,
+        event_content: &str,
+    ) -> Response {
+        let state_event_path = format!(
+            "/_matrix/client/r0/rooms/{}/state/{}?access_token={}",
+            room_id,
+            event_type,
+            access_token
+        );
+
+        self.put(&state_event_path, &event_content)
     }
 
     /// Create a User and Room.


### PR DESCRIPTION
This PR is based on #127 which should be addressed first, so don't mind the other commits.

Diesel currently lacks support for the query so raw SQL was used.

I created a quick custom struct (lacks proper serialization) to represent the response of the endpoint because currently we don't have anything that represents the examples of the spec. There are some extra or renamed fields from the ones in ruma-events. Should we create another type for these on ruma-events? Customize the existing ones? or use something like my example?