### PR TITLE
Add temporary UIAuth provider

### DIFF
--- a/src/api/r0/login.rs
+++ b/src/api/r0/login.rs
@@ -37,9 +37,59 @@ impl Handler for Login {
     }
 }
 
+/// Temporary UIAuth provider.
+pub struct LoginFlows;
+
+#[derive(Debug, Serialize)]
+struct Flows {
+    pub flows: Vec<LoginType>
+}
+
+#[derive(Debug, Serialize)]
+struct LoginType {
+    #[serde(rename="type")]
+    pub login_type: String
+}
+
+impl MiddlewareChain for LoginFlows {
+    fn chain() -> Chain {
+        Chain::new(LoginFlows)
+    }
+}
+
+impl Handler for LoginFlows {
+    fn handle(&self, _: &mut Request) -> IronResult<Response> {
+        let pass_login = LoginType { login_type: "m.login.password".to_string() };
+        let response = Flows { flows: vec![pass_login] };
+
+        Ok(Response::with((status::Ok, SerializableResponse(response))))
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use test::Test;
+
+    #[test]
+    fn get_available_flows() {
+        let test = Test::new();
+
+        let response = test.get("/_matrix/client/r0/login");
+        let flows = response.json().find("flows");
+
+        assert!(flows.is_some());
+        assert_eq!(flows.unwrap().as_array().unwrap().len(), 1);
+
+        let login_type = flows.unwrap()
+            .as_array().unwrap()
+            .get(0).unwrap()
+            .as_object().unwrap()
+            .get("type").unwrap()
+            .as_str().unwrap();
+
+        assert_eq!(login_type, "m.login.password");
+    }
 
     #[test]
     fn valid_credentials() {

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -9,7 +9,7 @@ pub use self::account::{
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
 pub use self::join::{InviteToRoom, JoinRoom, JoinRoomWithIdOrAlias};
-pub use self::login::Login;
+pub use self::login::{Login, LoginFlows};
 pub use self::logout::Logout;
 pub use self::members::Members;
 pub use self::profile::{Profile, GetAvatarUrl, PutAvatarUrl, GetDisplayName, PutDisplayName};

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,6 +20,7 @@ use api::r0::{
     GetRoomAlias,
     GetFilter,
     GetTags,
+    LoginFlows,
     InviteToRoom,
     JoinRoom,
     JoinRoomWithIdOrAlias,
@@ -79,6 +80,7 @@ impl<'a> Server<'a> {
             "delete_room_alias",
         );
         r0_router.put("/directory/room/:room_alias", PutRoomAlias::chain(), "put_room_alias");
+        r0_router.get("/login", LoginFlows::chain(), "login_flows");
         r0_router.post("/login", Login::chain(), "login");
         r0_router.post("/logout", Logout::chain(), "logout");
         r0_router.post("/register", Register::chain(), "register");


### PR DESCRIPTION
The endpoint is undocumented and it is used temporarily instead of the UIAuth flows. It should be removed shortly after. Currently the riot client queries this endpoint, before proceeding with the actual POST login request. 

The implementation is simple and self-contained so it can be removed easily in the future.

[Here](https://github.com/matrix-org/matrix-doc/issues/677) is the relevant issue on matrix-doc and [here](http://matrix.org/_matrix/client/r0/login) is what the endpoint looks like.