### PR TITLE
Give max power level to the creator of the room

### DIFF
--- a/src/api/r0/sync.rs
+++ b/src/api/r0/sync.rs
@@ -295,7 +295,7 @@ mod tests {
         let json = response.json();
         let events = json.find_path(&["rooms", "join", room_id.as_ref(), "timeline", "events"]).unwrap();
         assert!(events.is_array());
-        assert_eq!(events.as_array().unwrap().len(), 5);
+        assert_eq!(events.as_array().unwrap().len(), 6);
     }
 
     #[test]


### PR DESCRIPTION
- Give permissions through the initial state and by default.
- Remove hardcoded permissions for the creator when inviting a new user.