### PR TITLE
Add the packaging metadata to build the ruma snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,5 +17,5 @@ parts:
   ruma:
     source: .
     plugin: rust
-    rust-channel: nightly
-    build-packages: [gcc, libpq-dev, libsodium-dev, libssl-dev, openssl]
+    rust-revision: nightly-2016-12-19
+    build-packages: [gcc, libpq-dev, libsodium-dev, libssl-dev, openssl, pkg-config]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: ruma
+version: master
+summary: A Matrix homeserver client API written in Rust
+description: |
+  Ruma is a Matrix homeserver written in Rust. Ruma's approach to Matrix
+  emphasizes security and scalability.
+
+grade: devel
+confinement: strict
+
+apps:
+  ruma:
+    command: ruma
+    plugs: [network, network-bind]
+
+parts:
+  ruma:
+    source: .
+    plugin: rust
+    rust-channel: nightly
+    build-packages: [gcc, libpq-dev, libsodium-dev, libssl-dev, openssl]


### PR DESCRIPTION
This is a package for the secure installation of apps that will work in most Linux distributions.
Landing it upstream will enable to push builds to the Ubuntu store, and get updated versions to many users.