### PR TITLE
Implement tokenrefresh

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -30,7 +30,7 @@ Legend:
     <td>POST /login</td>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:white_check_mark:</td>
     <td></td>
     <td>POST /tokenrefresh</td>
   </tr>

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,7 +88,7 @@ impl<'a> Server<'a> {
         r0_router.post("/login", Login::chain(), "login");
         r0_router.post("/logout", Logout::chain(), "logout");
         r0_router.post("/register", Register::chain(), "register");
-        r0_router.post("/tokenrefresh", unimplemented, "token_refresh");
+        r0_router.post("/tokenrefresh", deprecated, "token_refresh");
         r0_router.put(
             "/user/:user_id/account_data/:type",
             PutAccountData::chain(),
@@ -193,6 +193,6 @@ impl<'a> Server<'a> {
     }
 }
 
-fn unimplemented(_request: &mut Request) -> IronResult<Response> {
-    Err(IronError::from(ApiError::unimplemented(None)))
+fn deprecated(_: &mut Request) -> IronResult<Response> {
+    Err(IronError::from(ApiError::unauthorized("tokenrefresh is no longer supported".to_string())))
 }


### PR DESCRIPTION
Implement it as well as upstream does that is.
This matches the upstream implementation exactly: https://github.com/matrix-org/synapse/blob/f5a4001bb116c468cc5e8e0ae04a1c570e2cb171/synapse/rest/client/v2_alpha/tokenrefresh.py#L35-L36i

There are plans to remove it entirely in the future, so there's no
reason to do anything more complicated here.

See also https://github.com/matrix-org/matrix-doc/pull/395 and https://github.com/matrix-org/synapse/pull/1654