### PR TITLE
Add the /rooms/:room_id/kick endpoint

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -205,7 +205,7 @@ Legend:
     <td>POST /rooms/:room_id/join</td>
   </tr>
   <tr>
-    <td align="center">:no_entry_sign:</td>
+    <td align="center">:white_check_mark:</td>
     <td><a href="https://github.com/ruma/ruma/issues/25">#25</a></td>
     <td>POST /rooms/:room_id/kick</td>
   </tr>

--- a/src/api/r0/mod.rs
+++ b/src/api/r0/mod.rs
@@ -8,7 +8,7 @@ pub use self::account::{
 };
 pub use self::directory::{GetRoomAlias, DeleteRoomAlias, PutRoomAlias};
 pub use self::event_creation::{SendMessageEvent, StateMessageEvent};
-pub use self::join::{InviteToRoom, JoinRoom, JoinRoomWithIdOrAlias, LeaveRoom};
+pub use self::join::{InviteToRoom, JoinRoom, JoinRoomWithIdOrAlias, KickFromRoom, LeaveRoom};
 pub use self::login::Login;
 pub use self::logout::Logout;
 pub use self::members::Members;

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,6 +25,7 @@ use api::r0::{
     InviteToRoom,
     JoinRoom,
     JoinRoomWithIdOrAlias,
+    KickFromRoom,
     LeaveRoom,
     Login,
     Logout,
@@ -119,6 +120,7 @@ impl<'a> Server<'a> {
         r0_router.post("/rooms/:room_id/join", JoinRoom::chain(), "join_room");
         r0_router.post("/rooms/:room_id/invite", InviteToRoom::chain(), "invite_to_room");
         r0_router.post("/join/:room_id_or_alias", JoinRoomWithIdOrAlias::chain(), "join_room_with_alias");
+        r0_router.post("rooms/:room_id/kick", KickFromRoom::chain(), "kick_from_room");
         r0_router.post("rooms/:room_id/leave", LeaveRoom::chain(), "leave_room");
         r0_router.get("/rooms/:room_id/members", Members::chain(), "members");
         r0_router.get("/rooms/:room_id/state", RoomState::chain(), "get_room_state");

--- a/src/test.rs
+++ b/src/test.rs
@@ -232,6 +232,28 @@ impl Test {
         self.post(&path, &body)
     }
 
+    /// Kick a `User` from a `Room`.
+    pub fn kick_from_room(
+        &self,
+        access_token: &str,
+        room_id: &str,
+        user_id: &str,
+        reason: Option<&str>
+    ) -> Response {
+        let body = format!(
+            r#"{{"user_id": "{}", "reason": "{}"}}"#,
+            user_id,
+            reason.unwrap_or("")
+        );
+        let path = format!(
+            "/_matrix/client/r0/rooms/{}/kick?access_token={}",
+            room_id,
+            access_token
+        );
+
+        self.post(&path, &body)
+    }
+
     /// Look up a `RoomId` using an alias.
     pub fn get_room_by_alias(&self, alias: &str) -> Response {
         self.get(&format!("/_matrix/client/r0/directory/room/{}", alias))


### PR DESCRIPTION
I have opened matrix-org/matrix-doc#798 to address the `reason` field from the request.