### PR TITLE
Use ORDER BY clause to sort timeline events

### DIFF
--- a/src/models/event.rs
+++ b/src/models/event.rs
@@ -144,6 +144,7 @@ impl Event {
             .filter(events::event_type.like("m.room.%"))
             .filter(events::ordering.gt(since))
             .filter(events::room_id.eq(room_id))
+            .order(events::ordering.asc())
             .get_results(connection)
             .map_err(|err| match err {
                 DieselError::NotFound => ApiError::not_found(None),
@@ -161,6 +162,7 @@ impl Event {
             .filter(events::event_type.like("m.room.%"))
             .filter(events::ordering.lt(until))
             .filter(events::room_id.eq(room_id))
+            .order(events::ordering.asc())
             .get_results(connection)
             .map_err(|err| match err {
                 DieselError::NotFound => ApiError::not_found(None),


### PR DESCRIPTION
The timeline events should be sorted by the `ordering` field but there is no guaranteed ordering without an ORDER BY clause.

Fixes #140 and the related failure from #175 .