### PR TITLE
Use the previous next_batch token when there are no new events

### DIFF
--- a/src/models/presence_list.rs
+++ b/src/models/presence_list.rs
@@ -137,7 +137,10 @@ impl PresenceList {
         user_id: &UserId,
         since: Option<i64>
     ) -> Result<(i64, Vec<PresenceEvent>), ApiError> {
-        let mut max_ordering = -1;
+        let mut presence_key = match since {
+            Some(since) => since,
+            None => 0,
+        };
 
         let observed_users = PresenceList::find_observed_users(connection, user_id)?;
         let users_status = PresenceStatus::get_users(connection, &observed_users, since)?;
@@ -151,7 +154,7 @@ impl PresenceList {
 
         for status in users_status {
             let last_update = status.updated_at.0;
-            max_ordering = cmp::max(last_update, max_ordering);
+            presence_key = cmp::max(last_update, presence_key);
 
             let presence_state: PresenceState = status.presence.parse().unwrap();
             let last_active_ago = get_now() - last_update;
@@ -183,6 +186,6 @@ impl PresenceList {
             events.push(event);
         }
 
-        Ok((max_ordering, events))
+        Ok((presence_key, events))
     }
 }


### PR DESCRIPTION
Currently in order to compute the next_batch token for the /sync
response we start from an initial value (zero), and compare it with the
ordering of the new events to get the maximum value. If there are no new
events to compare with the returned value is zero. This process is
repeated for the room and the presence key.

To fix this we use the current since parameter (if present) as a
starting point instead of zero.

Also the `max_ordering` variable in presence was renamed to `presence_key`
to better reflect its usage since the timestamp is used as a next_batch
identifier for presence and not the event ordering.